### PR TITLE
Handling of webform type

### DIFF
--- a/modules/os2forms_nemid/os2forms_nemid.module
+++ b/modules/os2forms_nemid/os2forms_nemid.module
@@ -68,13 +68,10 @@ function os2forms_nemid_webform_submission_form_alter(array &$form, FormStateInt
   $webformNemidSettings = $webform->getThirdPartySetting('os2forms', 'os2forms_nemid');
 
   // Getting webform_type setting.
-  $webform_type = NULL;
-  if (isset($webformNemidSettings['webform_type']) && !empty($webformNemidSettings['webform_type'])) {
-    $webform_type = $webformNemidSettings['webform_type'];
-  }
+  $webform_type = !empty($webformNemidSettings['webform_type']) ? $webformNemidSettings['webform_type'] : NULL;
 
   // Webform type is set and not empty.
-  if ($webform_type) {
+  if (NULL !== $webform_type) {
     // Initializing AuthProviderInterface plugin.
     /** @var \Drupal\os2web_nemlogin\Service\AuthProviderService $authProviderService */
     $authProviderService = \Drupal::service('os2web_nemlogin.auth_provider');

--- a/modules/os2forms_nemid/src/Plugin/WebformElement/NemidElementBase.php
+++ b/modules/os2forms_nemid/src/Plugin/WebformElement/NemidElementBase.php
@@ -56,26 +56,26 @@ abstract class NemidElementBase extends WebformElementBase implements NemidPrepo
 
       if (NULL !== $webform_type) {
         $this->handleElementVisibility($element, $webform_type);
-      }
 
-      /** @var \Drupal\os2web_nemlogin\Service\AuthProviderService $authProviderService */
-      $authProviderService = \Drupal::service('os2web_nemlogin.auth_provider');
-      /** @var \Drupal\os2web_nemlogin\Plugin\AuthProviderInterface $plugin */
-      $plugin = $authProviderService->getActivePlugin();
+        /** @var \Drupal\os2web_nemlogin\Service\AuthProviderService $authProviderService */
+        $authProviderService = \Drupal::service('os2web_nemlogin.auth_provider');
+        /** @var \Drupal\os2web_nemlogin\Plugin\AuthProviderInterface $plugin */
+        $plugin = $authProviderService->getActivePlugin();
 
-      if ($plugin->isAuthenticated()) {
-        // Handle fields visibility depending on Authorization type.
-        if ($plugin->isAuthenticatedPerson()) {
-          $this->handleElementVisibility($element, OS2FORMS_NEMID_WEBFORM_TYPE_PERSONAL);
+        if ($plugin->isAuthenticated()) {
+          // Handle fields visibility depending on Authorization type.
+          if ($plugin->isAuthenticatedPerson()) {
+            $this->handleElementVisibility($element, OS2FORMS_NEMID_WEBFORM_TYPE_PERSONAL);
+          }
+          if ($plugin->isAuthenticatedCompany()) {
+            $this->handleElementVisibility($element, OS2FORMS_NEMID_WEBFORM_TYPE_COMPANY);
+          }
+
+          $this->handleElementPrepopulate($element, $form_state);
         }
-        if ($plugin->isAuthenticatedCompany()) {
-          $this->handleElementVisibility($element, OS2FORMS_NEMID_WEBFORM_TYPE_COMPANY);
-        }
 
-        $this->handleElementPrepopulate($element, $form_state);
+        NestedArray::setValue($form['elements'], $element['#webform_parents'], $element);
       }
-
-      NestedArray::setValue($form['elements'], $element['#webform_parents'], $element);
     }
   }
 

--- a/modules/os2forms_nemid/src/Plugin/WebformElement/NemidElementBase.php
+++ b/modules/os2forms_nemid/src/Plugin/WebformElement/NemidElementBase.php
@@ -52,12 +52,9 @@ abstract class NemidElementBase extends WebformElementBase implements NemidPrepo
       // Getting webform type settings.
       $webform = $webformSubmission->getWebform();
       $webformNemidSettings = $webform->getThirdPartySetting('os2forms', 'os2forms_nemid');
-      $webform_type = NULL;
+      $webform_type = !empty($webformNemidSettings['webform_type']) ? $webformNemidSettings['webform_type'] : NULL;
 
-      // If webform type is set, handle element visiblity.
-      if (isset($webformNemidSettings['webform_type'])) {
-        $webform_type = $webformNemidSettings['webform_type'];
-
+      if (NULL !== $webform_type) {
         $this->handleElementVisibility($element, $webform_type);
       }
 
@@ -89,15 +86,11 @@ abstract class NemidElementBase extends WebformElementBase implements NemidPrepo
     // Getting webform type settings.
     $webform = $webform_submission->getWebform();
     $webformNemidSettings = $webform->getThirdPartySetting('os2forms', 'os2forms_nemid');
-    $webform_type = NULL;
+    $webform_type = !empty($webformNemidSettings['webform_type']) ? $webformNemidSettings['webform_type'] : NULL;
 
     // If webform type is set, handle element visiblity.
-    if (isset($webformNemidSettings['webform_type'])) {
-      $webform_type = $webformNemidSettings['webform_type'];
-
-      if (!$this->isVisible($webform_type)) {
-        return NULL;
-      }
+    if (NULL !== $webform_type && !$this->isVisible($webform_type)) {
+      return NULL;
     }
 
     return parent::build($format, $element, $webform_submission, $options);


### PR DESCRIPTION
Pre-population of webform fields should only happen when webform type, i.e. “personal” or “company”, is actually set on the form.

- Cleaned up handling of webform_type setting
- Pre-populated fields only when webform type is set
