### PR TITLE
Added ability to update Drupal 8 solutions to 3.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "drupal/entity_print": "^2.1",
         "drupal/webform_migrate": "^1.1",
         "drupal/maillog": "1.x-dev",
-        "drupal/permissions_by_term": "^3.1",
+        "drupal/permissions_by_term": "^3.1 || ^2.25",
         "phpoffice/phpword": "^0.18.2",
         "tecnickcom/tcpdf": "~6",
         "vaimo/composer-patches": "^4.20",


### PR DESCRIPTION
To let OS2Forms installations that are still using Drupal 8 get better and smooth update to Drupal 9
I'd like to update os2forms to v3.

The current state of os2forms to v3 has a blocker for it.
The 3rd version of module permissions_by_term is not compatible with Drupal 8 
https://www.drupal.org/project/permissions_by_term/releases/3.1.17

The proposed resolution is to let os2forms to v3 use 
```
"drupal/permissions_by_term": "^3.1 || ^2.25",
```
