### PR TITLE
OS2FORMS-372 Added Easy person validation by CPR and name

### DIFF
--- a/src/Element/Os2formsPersonLookup.php
+++ b/src/Element/Os2formsPersonLookup.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\os2forms\Element;
+
+use Drupal\webform\Element\WebformCompositeBase;
+
+/**
+ * Provides a webform element for the os2forms person lookup element.
+ *
+ * @FormElement("os2forms_person_lookup")
+ */
+class Os2formsPersonLookup extends WebformCompositeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getCompositeElements(array $element) {
+    $elements = [];
+    $elements['cpr_number'] = [
+      '#type' => 'textfield',
+      '#title' => t('CPR number'),
+      '#required' => TRUE,
+    ];
+    $elements['name'] = [
+      '#type' => 'textfield',
+      '#title' => t('Name'),
+      '#required' => TRUE,
+    ];
+    return $elements;
+  }
+
+}

--- a/src/Element/Os2formsPersonLookup.php
+++ b/src/Element/Os2formsPersonLookup.php
@@ -18,12 +18,12 @@ class Os2formsPersonLookup extends WebformCompositeBase {
     $elements = [];
     $elements['cpr_number'] = [
       '#type' => 'textfield',
-      '#title' => t('CPR number'),
+      '#title' => t('CPR nummer'),
       '#required' => TRUE,
     ];
     $elements['name'] = [
       '#type' => 'textfield',
-      '#title' => t('Name'),
+      '#title' => t('Navn'),
       '#required' => TRUE,
     ];
     return $elements;

--- a/src/Element/Os2formsPersonLookup.php
+++ b/src/Element/Os2formsPersonLookup.php
@@ -18,7 +18,7 @@ class Os2formsPersonLookup extends WebformCompositeBase {
     $elements = [];
     $elements['cpr_number'] = [
       '#type' => 'textfield',
-      '#title' => t('CPR nummer'),
+      '#title' => t('CPR-nummer'),
       '#required' => TRUE,
     ];
     $elements['name'] = [

--- a/src/Plugin/WebformElement/Os2formsPersonLookup.php
+++ b/src/Plugin/WebformElement/Os2formsPersonLookup.php
@@ -14,7 +14,7 @@ use Drupal\webform\WebformSubmissionInterface;
  * @WebformElement(
  *   id = "os2forms_person_lookup",
  *   label = @Translation("CPR / Navn validering"),
- *   description = @Translation("Giver en nem validering med CPR nummer"),
+ *   description = @Translation("Giver en nem validering med CPR-nummer"),
  *   category = @Translation("OS2Forms"),
  *   composite = TRUE,
  *   multiline = TRUE,
@@ -59,7 +59,7 @@ class Os2formsPersonLookup extends WebformCompositeBase {
   public function initializeCompositeElements(array &$element) {
     $element['#webform_composite_elements'] = [
       'cpr_number' => [
-        '#title' => $this->t('CPR nummer'),
+        '#title' => $this->t('CPR-nummer'),
         '#type' => 'textfield',
         '#maxlength' => 255,
         '#required' => TRUE,
@@ -107,7 +107,7 @@ class Os2formsPersonLookup extends WebformCompositeBase {
     if (!$personsData['status']) {
       $error = isset($personsData['text']) ? $personsData['text'] : (isset($personsData['error']) ? $personsData['error'] : t('Can not verify CPR Number'));
       \Drupal::logger('os2forms')->warning(t('os2forms_person_lookup - data lookup error: @error', ['@error' => $error]));
-      $form_state->setError($element['cpr_number'], t('Navn og CPR nummer stemmer ikke overens.'));
+      $form_state->setError($element['cpr_number'], t('Navn og CPR-nummer stemmer ikke overens.'));
 
       return;
     }
@@ -119,7 +119,7 @@ class Os2formsPersonLookup extends WebformCompositeBase {
 
     $helper = new NameHelper();
     if ($helper->compareNames($personsData['adresseringsnavn'], $values['name']) !== 0) {
-      $form_state->setError($element['name'], t('Navn og CPR nummer stemmer ikke overens.'));
+      $form_state->setError($element['name'], t('Navn og CPR-nummer stemmer ikke overens.'));
     }
   }
 }

--- a/src/Plugin/WebformElement/Os2formsPersonLookup.php
+++ b/src/Plugin/WebformElement/Os2formsPersonLookup.php
@@ -13,8 +13,8 @@ use Drupal\webform\WebformSubmissionInterface;
  *
  * @WebformElement(
  *   id = "os2forms_person_lookup",
- *   label = @Translation("Easy CPR person lookup"),
- *   description = @Translation("Provides an easy person lookup element by CPR number"),
+ *   label = @Translation("CPR / Navn validering"),
+ *   description = @Translation("Giver en nem validering med CPR nummer"),
  *   category = @Translation("OS2Forms"),
  *   composite = TRUE,
  *   multiline = TRUE,
@@ -59,13 +59,13 @@ class Os2formsPersonLookup extends WebformCompositeBase {
   public function initializeCompositeElements(array &$element) {
     $element['#webform_composite_elements'] = [
       'cpr_number' => [
-        '#title' => $this->t('CPR number'),
+        '#title' => $this->t('CPR nummer'),
         '#type' => 'textfield',
         '#maxlength' => 255,
         '#required' => TRUE,
       ],
       'name' => [
-        '#title' => $this->t('Name'),
+        '#title' => $this->t('Navn'),
         '#type' => 'textfield',
         '#maxlength' => 255,
         '#required' => TRUE,
@@ -107,7 +107,7 @@ class Os2formsPersonLookup extends WebformCompositeBase {
     if (!$personsData['status']) {
       $error = isset($personsData['text']) ? $personsData['text'] : (isset($personsData['error']) ? $personsData['error'] : t('Can not verify CPR Number'));
       \Drupal::logger('os2forms')->warning(t('os2forms_person_lookup - data lookup error: @error', ['@error' => $error]));
-      $form_state->setError($element['cpr_number'], t('CPR is not valid.'));
+      $form_state->setError($element['cpr_number'], t('Navn og CPR nummer stemmer ikke overens.'));
 
       return;
     }
@@ -119,7 +119,7 @@ class Os2formsPersonLookup extends WebformCompositeBase {
 
     $helper = new NameHelper();
     if ($helper->compareNames($personsData['adresseringsnavn'], $values['name']) != 0) {
-      $form_state->setError($element['name'], t('Name: @name does not belong given CPR number', ['@name' => $values['name']]));
+      $form_state->setError($element['name'], t('Navn og CPR nummer stemmer ikke overens.'));
     }
   }
 }

--- a/src/Plugin/WebformElement/Os2formsPersonLookup.php
+++ b/src/Plugin/WebformElement/Os2formsPersonLookup.php
@@ -101,10 +101,10 @@ class Os2formsPersonLookup extends WebformCompositeBase {
 
     /** @var \Drupal\os2web_datalookup\Plugin\os2web\DataLookup\ServiceplatformenCPR $servicePlatformentCprPlugin */
     $servicePlatformentCprPlugin = $os2web_datalookup_plugins->createInstance('serviceplatformen_cpr');
-    $peronsData = $servicePlatformentCprPlugin->cprBasicInformation($cpr_number);
+    $personsData = $servicePlatformentCprPlugin->cprBasicInformation($cpr_number);
 
-    if (!$peronsData['status']) {
-      $error = isset($peronsData['text']) ? $peronsData['text'] : (isset($peronsData['error']) ? $peronsData['error'] : t('Can not verify CPR Number'));
+    if (!$personsData['status']) {
+      $error = isset($personsData['text']) ? $personsData['text'] : (isset($personsData['error']) ? $personsData['error'] : t('Can not verify CPR Number'));
       \Drupal::logger('os2forms')->warning(t('os2forms_person_lookup - data lookup error: @error', ['@error' => $error]));
       $form_state->setError($element['cpr_number'], t('CPR is not valid.'));
 
@@ -116,7 +116,7 @@ class Os2formsPersonLookup extends WebformCompositeBase {
       return;
     }
 
-    if ($peronsData['adresseringsnavn'] != $values['name']) {
+    if ($personsData['adresseringsnavn'] != $values['name']) {
       $form_state->setError($element['name'], t('Name: @name does not belong given CPR number', ['@name' => $values['name']]));
     }
   }

--- a/src/Plugin/WebformElement/Os2formsPersonLookup.php
+++ b/src/Plugin/WebformElement/Os2formsPersonLookup.php
@@ -118,7 +118,7 @@ class Os2formsPersonLookup extends WebformCompositeBase {
     }
 
     $helper = new NameHelper();
-    if ($helper->compareNames($personsData['adresseringsnavn'], $values['name']) != 0) {
+    if ($helper->compareNames($personsData['adresseringsnavn'], $values['name']) !== 0) {
       $form_state->setError($element['name'], t('Navn og CPR nummer stemmer ikke overens.'));
     }
   }

--- a/src/Plugin/WebformElement/Os2formsPersonLookup.php
+++ b/src/Plugin/WebformElement/Os2formsPersonLookup.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\os2forms\Plugin\WebformElement;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
+use Drupal\webform\WebformInterface;
+use Drupal\webform\WebformSubmissionInterface;
+
+/**
+ * Provides a 'os2forms_person_lookup' element.
+ *
+ * @WebformElement(
+ *   id = "os2forms_person_lookup",
+ *   label = @Translation("Easy CPR person lookup"),
+ *   description = @Translation("Provides an easy person lookup element by CPR number"),
+ *   category = @Translation("OS2Forms"),
+ *   composite = TRUE,
+ *   multiline = TRUE,
+ *   states_wrapper = TRUE,
+ *   dependencies = {
+ *     "os2web_datalookup",
+ *   }
+ * )
+ *
+ * @see \Drupal\address\Element\Address
+ */
+class Os2formsPersonLookup extends WebformCompositeBase {
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineDefaultProperties() {
+    $properties = parent::defineDefaultProperties();
+
+    $composite_elements = $this->getCompositeElements();
+    foreach ($composite_elements as $composite_key => $composite_element) {
+      if (isset($properties[$composite_key . '__required'])) {
+        $properties[$composite_key . '__required'] = TRUE;
+      }
+    }
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function prepareElementValidateCallbacks(array &$element, WebformSubmissionInterface $webform_submission = NULL) {
+    parent::prepareElementValidateCallbacks($element, $webform_submission);
+
+    $element['#element_validate'][] = [get_class($this), 'validatePerson'];
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @see \Drupal\address\Plugin\Field\FieldType\AddressItem::schema
+   */
+  public function initializeCompositeElements(array &$element) {
+    $element['#webform_composite_elements'] = [
+      'cpr_number' => [
+        '#title' => $this->t('CPR number'),
+        '#type' => 'textfield',
+        '#maxlength' => 255,
+        '#required' => TRUE,
+      ],
+      'name' => [
+        '#title' => $this->t('Name'),
+        '#type' => 'textfield',
+        '#maxlength' => 255,
+        '#required' => TRUE,
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTestValues(array $element, WebformInterface $webform, array $options = []) {
+    return [
+      [
+        'cpr_number' => '123456-7890',
+        'name' => 'John Smith',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepare(array &$element, WebformSubmissionInterface $webform_submission = NULL) {
+    parent::prepare($element, $webform_submission);
+  }
+
+  /**
+   * Form API callback. Make sure CPR is valid and belong provided name.
+   */
+  public static function validatePerson(array &$element, FormStateInterface $form_state, array &$completed_form) {
+    $values = $element['#value'];
+    $cpr_number = str_replace('-', '', $values['cpr_number']);
+    $os2web_datalookup_plugins = \Drupal::service('plugin.manager.os2web_datalookup');
+
+    /** @var \Drupal\os2web_datalookup\Plugin\os2web\DataLookup\ServiceplatformenCPR $servicePlatformentCprPlugin */
+    $servicePlatformentCprPlugin = $os2web_datalookup_plugins->createInstance('serviceplatformen_cpr');
+    $peronsData = $servicePlatformentCprPlugin->cprBasicInformation($cpr_number);
+
+    if (!$peronsData['status']) {
+      $error = isset($peronsData['text']) ? $peronsData['text'] : (isset($peronsData['error']) ? $peronsData['error'] : t('Can not verify CPR Number'));
+      \Drupal::logger('os2forms')->warning(t('os2forms_person_lookup - data lookup error: @error', ['@error' => $error]));
+      $form_state->setError($element['cpr_number'], t('CPR is not valid.'));
+
+      return;
+    }
+
+    // Do not run person lookup validation by name if it's hidden.
+    if ($element['#name__access'] === FALSE) {
+      return;
+    }
+
+    if ($peronsData['adresseringsnavn'] != $values['name']) {
+      $form_state->setError($element['name'], t('Name: @name does not belong given CPR number', ['@name' => $values['name']]));
+    }
+  }
+}

--- a/src/Plugin/WebformElement/Os2formsPersonLookup.php
+++ b/src/Plugin/WebformElement/Os2formsPersonLookup.php
@@ -3,6 +3,7 @@
 namespace Drupal\os2forms\Plugin\WebformElement;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\os2forms\Utility\NameHelper;
 use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
 use Drupal\webform\WebformInterface;
 use Drupal\webform\WebformSubmissionInterface;
@@ -116,7 +117,8 @@ class Os2formsPersonLookup extends WebformCompositeBase {
       return;
     }
 
-    if ($personsData['adresseringsnavn'] != $values['name']) {
+    $helper = new NameHelper();
+    if ($helper->compareNames($personsData['adresseringsnavn'], $values['name']) != 0) {
       $form_state->setError($element['name'], t('Name: @name does not belong given CPR number', ['@name' => $values['name']]));
     }
   }

--- a/src/Utility/NameHelper.php
+++ b/src/Utility/NameHelper.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\os2forms\Utility;
+
+/**
+ * Provides functionality to compare name strings.
+ */
+final class NameHelper
+{
+    /**
+     * Compare first part of names ignoring case.
+     *
+     * The “first part” of a name is defined as the longest prefix consisting
+     * only of letters.
+     */
+    public function compareNames(string $a, string $b)
+    {
+        $normA = $this->normalizeName($a);
+        $normB = $this->normalizeName($b);
+
+        // Keep only first name (excluding dash).
+        $wordA = preg_replace('/[[:space:]-].*/', '', $normA);
+        $wordB = preg_replace('/[[:space:]-].*/', '', $normB);
+
+        return strcasecmp($wordA, $wordB);
+    }
+
+    /**
+     * Normalize a name
+     */
+    public function normalizeName(string $name): string
+    {
+        // Convert to ASCII.
+        $normalized = iconv("utf-8", "ascii//TRANSLIT", $name);
+
+        // Remove leading and trailing whitespace.
+        $normalized = trim($normalized);
+        // Normalize whitespace.
+        $normalized = preg_replace('/[[:space:]]+/', ' ', $normalized);
+
+        // Remove everything that's not a letter, a space or a dash.
+        $normalized = preg_replace('/[^[:alpha:] -]+/', '', $normalized);
+
+        return $normalized;
+    }
+}


### PR DESCRIPTION
Changes in PR implement a composite field "Easy CPR person lookup"

With default settings you will get  2 fields:
- CPR number
- Name

Value from CPR number validates over correct CPR number.
For valid CPR, Name it matches with data retrieved from Service platformen.
