### PR TITLE
Removed NemID authentication from AJAX requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 - Removed vaimo/composer-patches as dependency
 - Changed composer patching configuration slightly
 - Applied coding standards. Updated GitHub Actions.
+- Removed NemID authentication message from AJAX requests
 
 ## [3.3.0] 2022-12-22
 - Added OS2Forms attachment component (with custom heards, footer and colophon) (OS2FORMS-361)

--- a/modules/os2forms_nemid/src/EventSubscriber/NemloginRedirectSubscriber.php
+++ b/modules/os2forms_nemid/src/EventSubscriber/NemloginRedirectSubscriber.php
@@ -171,7 +171,9 @@ class NemloginRedirectSubscriber implements EventSubscriberInterface {
       }
       else {
         $settingFormConfig = $this->configFactory->get(SettingsForm::$configName);
-        if (!$settingFormConfig->get('os2forms_nemid_hide_active_nemid_session_message')) {
+        if (!$settingFormConfig->get('os2forms_nemid_hide_active_nemid_session_message')
+          // Don't show the message in AJAX requests, e.g. when uploading files.
+          && !$request->isXmlHttpRequest()) {
           $this->messenger
             ->addMessage($this->t('This webform requires a valid NemID authentication and is not visible without it. You currently have an active NemID authentication session. If you do not want to proceed with this webform press <a href="@logout">log out</a> to return back to the front page.', [
               '@logout' => $this->nemloginAuthProvider->getLogoutUrl(['query' => ['destination' => Url::fromRoute('<front>')->toString()]])


### PR DESCRIPTION
When performing AJAX requests on a form, e.g. when uploading a file, the NemID authentication message is added as part of the AJAX response and hence shown multiple timed on the page.

This change adds a check for AJAX requests before adding the message.

<img width="1301" alt="Screenshot 2022-08-16 at 11 24 31" src="https://user-images.githubusercontent.com/11267554/184845798-d101b916-9a50-4267-8177-f967c9a0e888.png">

