### PR TITLE
Updated to drupal/webform_validation:^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "vaimo/composer-patches": "^4.20",
         "os2web/os2web_datalookup": "^1.0",
         "os2web/os2web_nemlogin": "^1.0",
-        "drupal/webform_validation": "2.0.x-dev",
+        "drupal/webform_validation": "^2.0",
         "drupal/webform_remote_select": "^1.0.6"
     },
     "require-dev": {
@@ -71,7 +71,8 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "vaimo/composer-patches": true
         }
     },
     "scripts": {


### PR DESCRIPTION
Updates to drupal/webform_validation:^2.0 (which is currently https://www.drupal.org/project/webform_validation/releases/2.0.0-alpha2).