### PR TITLE
Fix typo in os2forms_attachment module default setting keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See ["how do I make a good changelog record?"](https://keepachangelog.com/en/1.0
 before starting to add changes. Use example [placed in the end of the page](#example-of-change-log-record)
 
 ## [Unreleased]
+- Fixed `Undefined array key` in os2forms_attachment module
 
 ## [3.4.0] 2023-02-15
 - Added github action for checking changelog changes when creating pull requests

--- a/modules/os2forms_attachment/os2forms_attachment.module
+++ b/modules/os2forms_attachment/os2forms_attachment.module
@@ -191,19 +191,14 @@ function _os2forms_attachment_print_form_add_template_override(array &$element, 
       $footer_options['Custom'][$footer->id()] = $footer->label();
     }
   }
-  // Template.
-  $template_settings += [
-    'os2forms_header' => '',
-    'os2forms_colophon' => '',
-    'os2forms_footer' => '',
-  ];
+
   $element['webform_entity_print']['template']['os2form_header'] = [
     '#type' => 'select',
     '#title' => t('OS2forms header override'),
     '#options' => $header_options,
     '#description' => t('Select default header that will be used on all forms (use standard for no override)'),
     '#empty_option' => t('Use standard'),
-    '#default_value' => $template_settings['os2form_header'],
+    '#default_value' => $template_settings['os2forms_header'] ?? '',
     '#weight' => -1,
   ];
 
@@ -213,7 +208,7 @@ function _os2forms_attachment_print_form_add_template_override(array &$element, 
     '#options' => $colophon_options,
     '#description' => t('Select default colophon that will be used on all forms (use standard for no override)'),
     '#empty_option' => t('Use standard'),
-    '#default_value' => $template_settings['os2form_colophon'],
+    '#default_value' => $template_settings['os2forms_colophon'] ?? '',
     '#weight' => -1,
   ];
 
@@ -223,7 +218,7 @@ function _os2forms_attachment_print_form_add_template_override(array &$element, 
     '#options' => $footer_options,
     '#description' => t('Select default footer that will be used on all forms (use standard for no override)'),
     '#empty_option' => t('Use standard'),
-    '#default_value' => $template_settings['os2form_footer'],
+    '#default_value' => $template_settings['os2forms_footer'] ?? '',
     '#weight' => 0,
   ];
 


### PR DESCRIPTION
Fixes

```
Warning: Undefined array key "os2form_footer" in _os2forms_attachment_print_form_add_template_override()
(line 226 of /data/www/selvbetjening_aarhuskommune_dk/htdocs/web/modules/contrib/os2forms/modules/os2forms_attachment/os2forms_attachment.module)
```

https://github.com/OS2Forms/os2forms/blob/develop/modules/os2forms_attachment/os2forms_attachment.module#L194-L228


