### PR TITLE
Replace non-existent entity.manager with entity_type.manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 - Added Maps element (<https://github.com/OS2Forms/os2forms/pull/39>).
 - Added missing dependency
 - Added changes to Map element after external review
+- Fixed non-existent service "entity.manager" in webform_embed module
 
 ## [3.4.0] 2023-02-15
 

--- a/modules/os2forms_sbsys/src/Element/WebformAttachmentSbsysXml.php
+++ b/modules/os2forms_sbsys/src/Element/WebformAttachmentSbsysXml.php
@@ -22,7 +22,7 @@ class WebformAttachmentSbsysXml extends WebformAttachmentXml {
 
     return $xmlContext;
   }
-  
+
   /**
    * {@inheritdoc}
    */

--- a/modules/os2forms_sbsys/src/Element/WebformAttachmentSbsysXml.php
+++ b/modules/os2forms_sbsys/src/Element/WebformAttachmentSbsysXml.php
@@ -22,6 +22,7 @@ class WebformAttachmentSbsysXml extends WebformAttachmentXml {
 
     return $xmlContext;
   }
+  
   /**
    * {@inheritdoc}
    */

--- a/modules/webform_embed/src/Controller/WebformEmbedController.php
+++ b/modules/webform_embed/src/Controller/WebformEmbedController.php
@@ -33,7 +33,7 @@ class WebformEmbedController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity.manager')
+      $container->get('entity_type.manager')
     );
   }
 


### PR DESCRIPTION
Webform Embed doesn't work properly since entity.manager no longer exists and should be replaced with entity_type.manager.