### PR TITLE
Handled nested elements in webform inherit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [#73](https://github.com/OS2Forms/os2forms/pull/73a)
+  Fix issue with nested elements in webform inherit
 - [#72](https://github.com/OS2Forms/os2forms/pull/72)
   Fix certificate testing, also testing for RSA/PEM certs as well as PKCS12
 

--- a/modules/os2forms_forloeb/src/Plugin/EngineTasks/MaestroWebformInheritTask.php
+++ b/modules/os2forms_forloeb/src/Plugin/EngineTasks/MaestroWebformInheritTask.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\os2forms_forloeb\Plugin\EngineTasks;
 
+use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\maestro\Engine\MaestroEngine;
 use Drupal\maestro_webform\Plugin\EngineTasks\MaestroWebformTask;
+use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\Utility\WebformArrayHelper;
 
@@ -152,9 +154,18 @@ class MaestroWebformInheritTask extends MaestroWebformTask {
           if ('webform_submission' === ($entityIdentifier['entity_type'] ?? NULL)) {
             $submission = WebformSubmission::load($entityIdentifier['entity_id']);
             $data = $submission->getData();
-            foreach ($data as $key => $value) {
-              if (isset($form['elements'][$key])) {
-                $form['elements'][$key]['#default_value'] = $value;
+
+            // The target element may be hidden inside sections or field groups
+            // on the target form. Therefore, we need to load that form and get
+            // element information to properly set default element values nested
+            // inside the form.
+            if ($targetWebform = Webform::load($form['#webform_id'] ?? NULL)) {
+              foreach ($data as $key => $value) {
+                if ($targetElement = $targetWebform->getElement($key)) {
+                  if ($element = &NestedArray::getValue($form['elements'], $targetElement['#webform_parents'])) {
+                    $element['#default_value'] = $value;
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
Fixes issue with webform elements not on top-level not being pre-filled.

The current implementation does not handle elements that are nested inside other elements.