### PR TITLE
FORMS-1000: Enabled existing color input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 - [#73](https://github.com/OS2Forms/os2forms/pull/73a)
   Fix issue with nested elements in webform inherit
+- [#77](https://github.com/OS2Forms/os2forms/pull/77)
+  Fix color picker fields in os2forms_webform_maps
 
 ## [3.13.2] 2023-10-19
 

--- a/modules/os2forms_webform_maps/src/Plugin/WebformElement/WebformLeafletMapField.php
+++ b/modules/os2forms_webform_maps/src/Plugin/WebformElement/WebformLeafletMapField.php
@@ -190,7 +190,7 @@ class WebformLeafletMapField extends WebformElementBase {
             ],
           ],
           'polyline_color' => [
-            '#type' => 'input_color',
+            '#type' => 'textfield',
             '#title' => 'Color',
             '#description' => $this->t('Enter value as HEX or CSS color'),
           ],
@@ -199,7 +199,7 @@ class WebformLeafletMapField extends WebformElementBase {
             '#title' => 'Prevent Intersection',
           ],
           'polyline_error_color' => [
-            '#type' => 'input_color',
+            '#type' => 'textfield',
             '#title' => 'Error color',
             '#description' => $this->t('Enter value as HEX or CSS color'),
             '#states' => [
@@ -233,7 +233,7 @@ class WebformLeafletMapField extends WebformElementBase {
             ],
           ],
           'rectangle_color' => [
-            '#type' => 'input_color',
+            '#type' => 'textfield',
             '#title' => 'Color',
             '#description' => $this->t('Enter value as HEX or CSS color'),
           ],
@@ -253,7 +253,7 @@ class WebformLeafletMapField extends WebformElementBase {
             ],
           ],
           'polygon_color' => [
-            '#type' => 'input_color',
+            '#type' => 'textfield',
             '#title' => 'Color',
             '#description' => $this->t('Enter value as HEX or CSS color'),
           ],
@@ -262,7 +262,7 @@ class WebformLeafletMapField extends WebformElementBase {
             '#title' => 'Prevent Intersection',
           ],
           'polygon_error_color' => [
-            '#type' => 'input_color',
+            '#type' => 'textfield',
             '#title' => 'Error color',
             '#states' => [
               'invisible' => [
@@ -296,7 +296,7 @@ class WebformLeafletMapField extends WebformElementBase {
             ],
           ],
           'circle_color' => [
-            '#type' => 'input_color',
+            '#type' => 'textfield',
             '#title' => 'Color',
             '#description' => $this->t('Enter value as HEX or CSS color'),
           ],


### PR DESCRIPTION
Changed field type 'input_color' to 'textfield' to reenable already existing color input fields in os2forms_webform_maps.

https://jira.itkdev.dk/browse/FORMS-1000