### PR TITLE
#592: Maestro flow task notification permission patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 ## [Unreleased]
 
 - CprFetchData adding ajax error fix
+- [#85](https://github.com/OS2Forms/os2forms/pull/85)
+  Patched Maestro task notification role permission.
 
 ## [3.14.0]
 

--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
                 "entityQuery reference JOINs should specify target_type (https://www.drupal.org/project/dynamic_entity_reference/issues/3120952#comment-14141038)": "https://www.drupal.org/files/issues/2021-06-22/entityquery-reference-joins-should-specify-target_type-3120952-24.patch"
             },
             "drupal/maestro": {
-                "Maestro task notification permission patch": "patches/drupal/maestro/maestro_task_select_notification_role_permission.patch"
+                "Maestro task notification permission patch": "https://gist.githubusercontent.com/jekuaitk/5595756eb1aaf4da5e780761ac619877/raw/340e16d23a99c3f0bf1044d144de222883c2ae01/maestro_task_select_notification_role_permission.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,9 @@
             },
             "drupal/dynamic_entity_reference": {
                 "entityQuery reference JOINs should specify target_type (https://www.drupal.org/project/dynamic_entity_reference/issues/3120952#comment-14141038)": "https://www.drupal.org/files/issues/2021-06-22/entityquery-reference-joins-should-specify-target_type-3120952-24.patch"
+            },
+            "drupal/maestro": {
+                "Maestro task notification permission patch": "patches/drupal/maestro/maestro_task_select_notification_role_permission.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
                 "entityQuery reference JOINs should specify target_type (https://www.drupal.org/project/dynamic_entity_reference/issues/3120952#comment-14141038)": "https://www.drupal.org/files/issues/2021-06-22/entityquery-reference-joins-should-specify-target_type-3120952-24.patch"
             },
             "drupal/maestro": {
-                "Maestro task notification permission patch": "https://gist.githubusercontent.com/jekuaitk/5595756eb1aaf4da5e780761ac619877/raw/340e16d23a99c3f0bf1044d144de222883c2ae01/maestro_task_select_notification_role_permission.patch"
+                "Maestro task notification permission patch": "web/modules/contrib/os2forms/patches/drupal/maestro/maestro_task_select_notification_role_permission.patch"
             }
         }
     },

--- a/patches/drupal/maestro/maestro_task_select_notification_role_permission.patch
+++ b/patches/drupal/maestro/maestro_task_select_notification_role_permission.patch
@@ -1,0 +1,17 @@
+diff --git a/src/MaestroTaskTrait.php b/src/MaestroTaskTrait.php
+index 9aefd9e..0133e0d 100644
+--- a/src/MaestroTaskTrait.php
++++ b/src/MaestroTaskTrait.php
+@@ -312,10 +312,10 @@ trait MaestroTaskTrait {
+ 
+     $form['edit_task_notifications']['select_notification_role'] = [
+       '#id' => 'select_notification_role',
+-      '#type' => 'textfield',
++      '#type' => 'entity_autocomplete',
++      '#target_type' => 'user_role',
+       '#default_value' => '',
+       '#title' => $this->t('Role'),
+-      '#autocomplete_route_name' => 'maestro.autocomplete.roles',
+       '#required' => FALSE,
+       '#prefix' => '<div class="maestro-engine-notifications-hidden-role">',
+       '#suffix' => '</div></div>',


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/592

* Maestro flow task notification role permission patch

Currently, users need the `administer site configuration` permission to configure notification on flows, whereas assigning the task does not. Patch updates the notification configuration (`select_notification_role`) to behave in the same manner as the assignment configuration (`select_assigned_role`) to align the two.

Patch has been added to a gist and referred to this way - i'm not sure if theres a better way of doing this.

