### PR TITLE
#1039: Added base_url variable to maestro notification twig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 - Adding Lat and Long fetching to DataAddress
 - [#84](https://github.com/OS2Forms/os2forms/pull/84)
   Added digital post test command.
+- [#95](https://github.com/OS2Forms/os2forms/pull/95)
+  Added `base_url` variable to Maestro notification twig.
 
 ## [3.14.1] 2024-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 - [#84](https://github.com/OS2Forms/os2forms/pull/84)
   Added digital post test command.
 - [#95](https://github.com/OS2Forms/os2forms/pull/95)
-   - Added `base_url` variable to twig templates.
-   - Tokenized all Maestro notification html.
+  - Added `base_url` variable to twig templates.
+  - Tokenized all Maestro notification html.
 
 ## [3.14.1] 2024-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 - [#84](https://github.com/OS2Forms/os2forms/pull/84)
   Added digital post test command.
 - [#95](https://github.com/OS2Forms/os2forms/pull/95)
-  Added `base_url` variable to Maestro notification twig.
+  Added `base_url` variable to twig templates.
 
 ## [3.14.1] 2024-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 - [#84](https://github.com/OS2Forms/os2forms/pull/84)
   Added digital post test command.
 - [#95](https://github.com/OS2Forms/os2forms/pull/95)
-  Added `base_url` variable to twig templates.
+   - Added `base_url` variable to twig templates.
+   - Tokenized all Maestro notification html.
 
 ## [3.14.1] 2024-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ before starting to add changes. Use example [placed in the end of the page](#exa
   Added digital post test command.
 - [#95](https://github.com/OS2Forms/os2forms/pull/95)
   - Added `base_url` variable to twig templates.
-  - Tokenized all Maestro notification html.
+  - Handled tokens in Maestro notification html.
 
 ## [3.14.1] 2024-01-16
 

--- a/modules/os2forms_attachment/README.md
+++ b/modules/os2forms_attachment/README.md
@@ -14,7 +14,6 @@ To specify headers/footers that will override the default ones on a global level
 
 To specify headers/footers that will override the default ones on a form level (**Third party settings** -> **Entity print** section): ```/admin/structure/webform/manage/[webform]/settings```
 
-
 # Overwriting templates
 
 With some setups it might be necessary to overwrite templates

--- a/modules/os2forms_attachment/README.md
+++ b/modules/os2forms_attachment/README.md
@@ -13,3 +13,23 @@ To add custom headers/footer ```admin/structure/webform/config/os2forms_attachme
 To specify headers/footers that will override the default ones on a global level (**Third party settings** -> **Entity print** section): ```admin/structure/webform/config```
 
 To specify headers/footers that will override the default ones on a form level (**Third party settings** -> **Entity print** section): ```/admin/structure/webform/manage/[webform]/settings```
+
+
+# Overwriting templates
+
+With some setups it might be necessary to overwrite templates
+in order to access stylesheets.
+
+For this reason the `base_url` variable has been added for use in templates.
+Set it in `settings.local.php`
+
+```php
+/**
+ * Base url.
+ *
+ * Used to specify full path to stylesheets in templates.
+ */
+$settings['base_url'] = 'http://nginx:8080';
+```
+
+and use it in templates with `{{ base_url }}`.

--- a/modules/os2forms_attachment/README.md
+++ b/modules/os2forms_attachment/README.md
@@ -17,18 +17,7 @@ To specify headers/footers that will override the default ones on a form level (
 # Overwriting templates
 
 With some setups it might be necessary to overwrite templates
-in order to access stylesheets.
+in order to access stylesheets or images.
 
-For this reason the `base_url` variable has been added for use in templates.
-Set it in `settings.local.php`
-
-```php
-/**
- * Base url.
- *
- * Used to specify full path to stylesheets in templates.
- */
-$settings['base_url'] = 'http://nginx:8080';
-```
-
-and use it in templates with `{{ base_url }}`.
+See [templates](modules/os2forms_forloeb/README.md#templates)
+for more details on how to do this.

--- a/modules/os2forms_attachment/os2forms_attachment.module
+++ b/modules/os2forms_attachment/os2forms_attachment.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Site\Settings;
 use Drupal\os2forms_attachment\Entity\AttachmentComponent;
 
 /**
@@ -316,4 +317,13 @@ function os2forms_attachment_module_implements_alter(&$implementations, $hook) {
       break;
   }
 
+}
+
+/**
+ * Implements hook_preprocess().
+ *
+ * Add 'base_url' variable to be used by templates.
+ */
+function os2forms_attachment_preprocess(&$vars) {
+  $vars['base_url'] = Settings::get('base_url');
 }

--- a/modules/os2forms_forloeb/README.md
+++ b/modules/os2forms_forloeb/README.md
@@ -19,7 +19,7 @@ You can also install the module by using Drush:
 Maestro 3.1 adds a `hook_webform_submission_form_alter` hook which we utilize to
 send assignment, reminder and escalation notifications by adding a *Maestro
 notification* handler to a form that spawns a Maestro workflow or assigns a
-task. If the notification recipient is identified by an an email address, the
+task. If the notification recipient is identified by an email address, the
 notification is sent as an email, and if the identifier is a Danish CPR number,
 the notifications is sent as digital post.
 
@@ -44,3 +44,19 @@ must be processed asynchronously. Specify the queue handling notification jobs.
 #### Templates
 
 Define templates for emails and digital post (PDF).
+
+With some setups it might be necessary to import stylesheets with a full path.
+
+For this reason the `base_url` variable has been added for use in templates.
+Set it in `settings.local.php`
+
+```php
+/**
+ * Base url.
+ *
+ * Used to specify full path to stylesheets in templates.
+ */
+$settings['base_url'] = 'http://nginx:8080';
+```
+
+and use it in templates with `{{ base_url }}`.

--- a/modules/os2forms_forloeb/README.md
+++ b/modules/os2forms_forloeb/README.md
@@ -45,18 +45,21 @@ must be processed asynchronously. Specify the queue handling notification jobs.
 
 Define templates for emails and digital post (PDF).
 
-With some setups it might be necessary to import stylesheets with a full path.
 
-For this reason the `base_url` variable has been added for use in templates.
-Set it in `settings.local.php`
+To reference assets, e.g. stylesheet or images, in your templates,
+you can use the `base_url` Twig variable to get the base URL:
+
+```html
+<link rel="stylesheet" href="{{ base_url }}/sites/default/templates/notification.html.twig
+```
+
+The value of `base_url` is defined in settings.local.php:
 
 ```php
 /**
  * Base url.
  *
- * Used to specify full path to stylesheets in templates.
+ * Used to specify full URL to stylesheets in templates.
  */
 $settings['base_url'] = 'http://nginx:8080';
 ```
-
-and use it in templates with `{{ base_url }}`.

--- a/modules/os2forms_forloeb/src/MaestroHelper.php
+++ b/modules/os2forms_forloeb/src/MaestroHelper.php
@@ -17,6 +17,7 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\Core\Render\Markup;
+use Drupal\Core\Site\Settings;
 use Drupal\Core\Url;
 use Drupal\entity_print\Plugin\EntityPrintPluginManagerInterface;
 use Drupal\maestro\Engine\MaestroEngine;
@@ -615,6 +616,7 @@ class MaestroHelper implements LoggerInterface {
         'action_label' => $actionLabel,
         'webform_submission' => $submission,
         'handler' => $this,
+        'base_url' => Settings::get('base_url')
       ],
     ];
 

--- a/modules/os2forms_forloeb/src/MaestroHelper.php
+++ b/modules/os2forms_forloeb/src/MaestroHelper.php
@@ -620,13 +620,11 @@ class MaestroHelper implements LoggerInterface {
 
     $html = trim((string) $this->webformThemeManager->renderPlain($build));
 
-    $html = $this->tokenManager->replace(
+    return Markup::create($this->tokenManager->replace(
       $html,
       $submission,
       $maestroTokenData
-    );
-
-    return Markup::create($html);
+    ));
   }
 
   /**

--- a/modules/os2forms_forloeb/src/MaestroHelper.php
+++ b/modules/os2forms_forloeb/src/MaestroHelper.php
@@ -618,7 +618,6 @@ class MaestroHelper implements LoggerInterface {
       ],
     ];
 
-
     $html = trim((string) $this->webformThemeManager->renderPlain($build));
 
     $html = $this->tokenManager->replace(

--- a/modules/os2forms_forloeb/src/MaestroHelper.php
+++ b/modules/os2forms_forloeb/src/MaestroHelper.php
@@ -616,7 +616,7 @@ class MaestroHelper implements LoggerInterface {
         'action_label' => $actionLabel,
         'webform_submission' => $submission,
         'handler' => $this,
-        'base_url' => Settings::get('base_url')
+        'base_url' => Settings::get('base_url'),
       ],
     ];
 


### PR DESCRIPTION
* Adds `base_url` variable to maestro notification twig
* Replaces tokens in all html rendered

Currently (with our docker setup) the stylesheet cannot be found if overwriting templates as seen in https://github.com/itk-dev/os2forms_selvbetjening/pull/291. 