### PR TITLE
Release 3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+## [3.15.0] 2024-05-03
+
 - Added webform encryption modules
 - Adding Lat and Long fetching to DataAddress
 - CprFetchData adding ajax error fix
@@ -216,7 +218,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 - Security in case of vulnerabilities.
 ```
 
-[Unreleased]: https://github.com/OS2Forms/os2forms/compare/3.14.1...HEAD
+[Unreleased]: https://github.com/OS2Forms/os2forms/compare/3.15.0...HEAD
+[3.15.0]: https://github.com/OS2Forms/os2forms/compare/3.14.1...3.15.0
 [3.14.1]: https://github.com/OS2Forms/os2forms/compare/3.14.0...3.14.1
 [3.14.0]: https://github.com/OS2Forms/os2forms/compare/3.13.3...3.14.0
 [3.13.3]: https://github.com/OS2Forms/os2forms/compare/3.13.2...3.13.3


### PR DESCRIPTION
Release 3.15.0

- Added webform encryption modules
- Adding Lat and Long fetching to DataAddress
- CprFetchData adding ajax error fix
- [#84](https://github.com/OS2Forms/os2forms/pull/84)
  Added digital post test command.
- Added FBS handler for supporting user creation in library systems
- [#95](https://github.com/OS2Forms/os2forms/pull/95)
  - Added `base_url` variable to twig templates.
  - Handled tokens in Maestro notification html.
- [#92](https://github.com/OS2Forms/os2forms/pull/92)
  Allow denying address protected citizen from webform.
- [#96](https://github.com/OS2Forms/os2forms/pull/96)
  NemLogin autologout pop-up styling.
- [#99](https://github.com/OS2Forms/os2forms/pull/99)
  Fix coding standards.
- [#102](https://github.com/OS2Forms/os2forms/pull/102)
  Fix array access with `purge_days` configuration.