### PR TITLE
Added missing return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- Added missing return type.
+
 ## [3.15.0] 2024-05-03
 
 - Added webform encryption modules

--- a/modules/os2forms_webform_list/src/CustomWebformEntityListBuilder.php
+++ b/modules/os2forms_webform_list/src/CustomWebformEntityListBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\os2forms_webform_list;
 
+use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\webform\WebformEntityListBuilder;
 
 /**
@@ -27,7 +28,7 @@ class CustomWebformEntityListBuilder extends WebformEntityListBuilder {
    * @return \Drupal\Core\Entity\Query\QueryInterface
    *   An entity query.
    */
-  protected function getQuery($keys = '', $category = '', $state = '') {
+  protected function getQuery($keys = '', $category = '', $state = ''): QueryInterface {
     $query = parent::getQuery($keys, $category, $state);
 
     // Setup a required condition for the list builder to respect webform update


### PR DESCRIPTION
With the addition of `drupal/webform_encrypt` `2.0.0-alpha1`, we are forced to upgrade to `drupal/webform` `^6.2` .

As described in https://www.drupal.org/project/webform/issues/3360357, the upgrade to `drupal/webform` `^6.2` requires an added return type.

* Added missing return type.