### PR TITLE
ITKDev: Added patch to support webform submission audit logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- Added patch to get `hook_webform_post_load_data` in webform submissions.
+
 ## [3.20.1] 2024-12-10
 
 - Avoided accessing non-initialized property when logging in `os2forms_nemid`.

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,9 @@
             },
             "drupal/webform": {
                 "Unlock possibility of using Entity print module export to Word": "https://www.drupal.org/files/issues/2020-02-29/3096552-6.patch",
-                "Webform computed element post save alter": "https://www.drupal.org/files/issues/2024-06-25/webform_computed_post_save_field_alter.patch"
+                "Webform computed element post save alter": "https://www.drupal.org/files/issues/2024-06-25/webform_computed_post_save_field_alter.patch",
+                "Add custom hook (hook_webform_post_load_data) for audit logging": "https://gist.githubusercontent.com/cableman/d26898fc8f65ee0a31001bf391583b59/raw/6189dc4c2ceaabb19d25cc4b98b0b3028a6b0e1e/gistfile1.txt"
+
             },
             "drupal/coc_forms_auto_export": {
                 "3240592 - Problem with phpseclib requirement in 2.x (https://www.drupal.org/project/coc_forms_auto_export/issues/3240592)": "https://www.drupal.org/files/issues/2021-10-04/requirement-namespace-3240592-1.patch",


### PR DESCRIPTION
When trying to hook into web-form submissions for audit logging (who have looked at data) in Drupal hooks that support both web-ui and API requests, one is left with `hook_entity_storage_load()`.

But because webform is webform and uses revision this hook is called before the storeage handler has loaded the submission data... sigh*.

So this patch resolves that issue be adding a custom hook (`hook__webform_post_load_data`) after webform has loaded submission data for a give submission revision.