### PR TITLE
ITKDEV: Used configured format in maestro notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- Updated Maestro notification handler assignment message format.
 - Updated `os2forms_fbs_handler` to use latest endpoints and operations.
 
 ## [3.21.0] 2024-12-17

--- a/modules/os2forms_forloeb/src/Plugin/WebformHandler/MaestroNotificationHandler.php
+++ b/modules/os2forms_forloeb/src/Plugin/WebformHandler/MaestroNotificationHandler.php
@@ -24,6 +24,7 @@ final class MaestroNotificationHandler extends WebformHandlerBase {
   public const NOTIFICATION = 'notification';
 
   public const TYPE = 'type';
+  public const FORMAT = 'format';
   public const SENDER_LABEL = 'sender_label';
   public const NOTIFICATION_ENABLE = 'notification_enable';
   public const NOTIFICATION_RECIPIENT = 'notification_recipient';
@@ -153,7 +154,7 @@ final class MaestroNotificationHandler extends WebformHandlerBase {
       }
       $form[self::NOTIFICATION][$notificationType][self::NOTIFICATION_CONTENT] = [
         '#type' => 'text_format',
-        '#format' => 'restricted_html',
+        '#format' => $this->configuration[self::NOTIFICATION][$notificationType][self::NOTIFICATION_CONTENT][self::FORMAT] ?? 'restricted_html',
         '#title' => $this->t('Message'),
         '#default_value' => $content ?? self::TOKEN_MAESTRO_TASK_URL,
         '#description' => $this->t('The actual notification content. Must contain the <code>@token_maestro_task_url</code> token which is the URL to the Maestro task.',


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/3246

* Uses configured text format when configuring maestro notification assignment message.