### PR TITLE
Moved os2forms_digital_signature changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 - [PR-179](https://github.com/OS2Forms/os2forms/pull/179)
   Remove unused and abandoned package `webmozart/path-util`.
+- [PR-167](https://github.com/OS2Forms/os2forms/pull/167)
+  Adding os2forms_digital_signature module
 
 ## [4.1.0] 2025-06-03
 
@@ -25,7 +27,6 @@ before starting to add changes. Use example [placed in the end of the page](#exa
   - Fix digital post commands
   - Updated versions in GitHub Actions `uses` steps
 - Updating the display of os2forms package on the status page
-- Adding os2forms_digital_signature module
 
 ## [4.0.0] 2025-03-06
 


### PR DESCRIPTION
* Moved `os2forms_digital_signature` CHANGELOG entry to `Unreleased` rather than `4.1.0`