### PR TITLE
#190: Rethrow exception to ensure failed job status in Maestro notifi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [PR-191](https://github.com/OS2Forms/os2forms/pull/191)
+  Re-throws exception to ensure failed status during Maestro notification job.
+
 ## [4.1.0] 2025-06-03
 
 - [PR-176](https://github.com/OS2Forms/os2forms/pull/176)


### PR DESCRIPTION
…cation

Handles https://github.com/OS2Forms/os2forms/issues/190.

Re-throws exception to ensure failed status during Maestro notification job.

> [!IMPORTANT]
> This PR is currently aimed at the **master** branch since the **develop** branch is many features ahead and a potential patch version should be without these features.