### PR TITLE
Release/selvbetjening 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [PR-191](https://github.com/OS2Forms/os2forms/pull/191)
+  Re-throws exception to ensure failed status during Maestro notification job.
+
 ## [4.1.0] 2025-06-03
 
 - [PR-176](https://github.com/OS2Forms/os2forms/pull/176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [PR-189](https://github.com/OS2Forms/os2forms/pull/189)
+  - Added support for MeMo 1.2 and added additional validation of MeMo actions.
+
 ## [4.1.0] 2025-06-03
 
 - [PR-176](https://github.com/OS2Forms/os2forms/pull/176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [PR-202](https://github.com/OS2Forms/os2forms/pull/202)
+  - Removed non-digits from recipient id in Maestro digital post notifications.
+
 ## [4.1.0] 2025-06-03
 
 - [PR-176](https://github.com/OS2Forms/os2forms/pull/176)

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "fig/http-message-util": "^1.1",
         "http-interop/http-factory-guzzle": "^1.0.0",
         "itk-dev/beskedfordeler-drupal": "^1.0",
-        "itk-dev/serviceplatformen": "dev-feature/5189-memo-1.2 as 1.7.0",
+        "itk-dev/serviceplatformen": "^1.7.1",
         "mglaman/composer-drupal-lenient": "^1.0",
         "os2web/os2web_audit": "^1.0",
         "os2web/os2web_datalookup": "^2.0",
@@ -79,10 +79,6 @@
         "wsdltophp/packagegenerator": "^4.0"
     },
     "repositories": {
-        "itk-dev/serviceplatformen": {
-            "type": "vcs",
-            "url": "https://github.com/itk-dev/serviceplatformen"
-        },
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "fig/http-message-util": "^1.1",
         "http-interop/http-factory-guzzle": "^1.0.0",
         "itk-dev/beskedfordeler-drupal": "^1.0",
-        "itk-dev/serviceplatformen": "^1.5",
+        "itk-dev/serviceplatformen": "dev-feature/5189-memo-1.2 as 1.7.0",
         "mglaman/composer-drupal-lenient": "^1.0",
         "os2web/os2web_audit": "^1.0",
         "os2web/os2web_datalookup": "^2.0",
@@ -79,6 +79,10 @@
         "wsdltophp/packagegenerator": "^4.0"
     },
     "repositories": {
+        "itk-dev/serviceplatformen": {
+            "type": "vcs",
+            "url": "https://github.com/itk-dev/serviceplatformen"
+        },
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"

--- a/modules/os2forms_digital_post/modules/os2forms_digital_post_examples/config/install/webform.webform.os2forms_digital_post_example_2.yml
+++ b/modules/os2forms_digital_post/modules/os2forms_digital_post_examples/config/install/webform.webform.os2forms_digital_post_example_2.yml
@@ -15,9 +15,9 @@ close: null
 uid: 1
 template: false
 archive: false
-id: os2forms_digital_post_example
-title: 'OS2Forms Digital post example'
-description: 'Simple example form with a digital post handler'
+id: os2forms_digital_post_example_2
+title: 'OS2Forms Digital post example with invalid handler URL'
+description: 'Simple example form with a digital post handler with invalid handler URL'
 category: Example
 elements: |-
   message:
@@ -240,10 +240,6 @@ handlers:
         actions:
           -
             action: INFORMATION
-            url: '[site:url]'
+            url: 'http://eksempel.dk'
             label: 'Se her!'
-          -
-            action: SELVBETJENING
-            url: 'https://eksempel.dk'
-            label: 'Eksempel'
 variants: {  }

--- a/modules/os2forms_digital_post/src/Drush/Commands/DigitalPostTestCommands.php
+++ b/modules/os2forms_digital_post/src/Drush/Commands/DigitalPostTestCommands.php
@@ -147,6 +147,8 @@ class DigitalPostTestCommands extends DrushCommands {
 
         $meMoMessage = $this->digitalPostHelper->getMeMoHelper()->buildMessage($recipientLookupResult, $senderLabel,
           $messageLabel, $document, $actions);
+        // If a valid memo-version option has been provided, set that version on
+        // the message.
         if ($meMoVersion) {
           $meMoMessage->setMemoVersion($meMoVersion);
         }

--- a/modules/os2forms_digital_post/src/Drush/Commands/DigitalPostTestCommands.php
+++ b/modules/os2forms_digital_post/src/Drush/Commands/DigitalPostTestCommands.php
@@ -133,17 +133,16 @@ class DigitalPostTestCommands extends DrushCommands {
     $io->section('Digital post');
     $io->definitionList(
       ['Type' => $type],
-      ['Document' => sprintf('%s (%s) (sanitized: %s)', $document->filename, $document->mimeType, SF1601::sanitizeFilename($document->filename))],
       ['Subject' => $subject],
       ['Message' => $message],
-      ['MeMe version' => $meMoVersion],
+      ['Document' => sprintf('%s (%s)', $document->filename, $document->mimeType)],
+      ['MeMo version' => $meMoVersion ?? '–'],
     );
 
     $actions = array_map($this->buildAction(...), $options['action']);
 
     foreach ($recipients as $recipient) {
       try {
-        $io->writeln(sprintf('Recipient: %s', $recipient));
         $recipientLookupResult = $this->digitalPostHelper->lookupRecipient($recipient);
 
         $meMoMessage = $this->digitalPostHelper->getMeMoHelper()->buildMessage($recipientLookupResult, $senderLabel,
@@ -158,6 +157,12 @@ class DigitalPostTestCommands extends DrushCommands {
           $type,
           $meMoMessage,
           $forsendelse
+        );
+
+        $io->definitionList(
+          ['Recipient' => $recipient],
+          ['Document' => sprintf('%s (%s)', $document->filename, $document->mimeType)],
+          ['MeMo version' => $meMoMessage->getMemoVersion()],
         );
 
         $io->success(sprintf('Digital post sent to %s (MeMo %s)', $recipient, $meMoMessage->getMemoVersion()));

--- a/modules/os2forms_digital_post/src/Helper/MeMoHelper.php
+++ b/modules/os2forms_digital_post/src/Helper/MeMoHelper.php
@@ -199,6 +199,8 @@ class MeMoHelper extends AbstractMessageHelper {
    *
    * @return \Drupal\Core\StringTranslation\TranslatableMarkup|null
    *   A message if the URL is not valid for an action.
+   *
+   * @phpstan-param array<string, mixed> $options
    */
   public static function validateActionUrl(string $url, array $options): ?TranslatableMarkup {
     // URL must be absolute and use https (cf. https://digitaliser.dk/digital-post/nyhedsarkiv/2024/nov/oeget-validering-i-digital-post)
@@ -214,6 +216,8 @@ class MeMoHelper extends AbstractMessageHelper {
         '%action' => self::getTranslatedActionName($options['action']),
       ]);
     }
+
+    return NULL;
   }
 
   /**
@@ -227,6 +231,9 @@ class MeMoHelper extends AbstractMessageHelper {
 
   /**
    * Get translated action names.
+   *
+   * @return array<string, string>
+   *   The translated action names.
    */
   public static function getTranslatedActionNames(): array {
     if (NULL === self::$translatedActionNames) {

--- a/modules/os2forms_digital_post/src/Helper/MeMoHelper.php
+++ b/modules/os2forms_digital_post/src/Helper/MeMoHelper.php
@@ -76,7 +76,7 @@ class MeMoHelper extends AbstractMessageHelper {
         (new File())
           ->setEncodingFormat($document->mimeType)
           ->setLanguage($document->language)
-          ->setFilename(SF1601::sanitizeFilename($document->filename))
+          ->setFilename($document->filename)
           ->setContent($document->content),
       ]);
 

--- a/modules/os2forms_digital_post/src/Helper/MeMoHelper.php
+++ b/modules/os2forms_digital_post/src/Helper/MeMoHelper.php
@@ -74,7 +74,7 @@ class MeMoHelper extends AbstractMessageHelper {
         (new File())
           ->setEncodingFormat($document->mimeType)
           ->setLanguage($document->language)
-          ->setFilename($document->filename)
+          ->setFilename(SF1601::sanitizeFilename($document->filename))
           ->setContent($document->content),
       ]);
 

--- a/modules/os2forms_digital_post/src/Plugin/WebformHandler/WebformHandlerSF1601.php
+++ b/modules/os2forms_digital_post/src/Plugin/WebformHandler/WebformHandlerSF1601.php
@@ -265,7 +265,7 @@ final class WebformHandlerSF1601 extends WebformHandlerBase {
           $formState->setErrorByName(
             self::MEMO_ACTIONS . '][actions][' . $index . '][url',
             $this->t('Url for action %action is required.', [
-              '%action' => $this->getTranslatedActionName($action['action']),
+              '%action' => MeMoHelper::getTranslatedActionName($action['action']),
             ])
           );
         }

--- a/modules/os2forms_forloeb/src/MaestroHelper.php
+++ b/modules/os2forms_forloeb/src/MaestroHelper.php
@@ -389,7 +389,10 @@ class MaestroHelper implements LoggerInterface {
       $senderLabel = $subject;
       $messageLabel = $subject;
 
-      $recipientLookupResult = $this->digitalPostHelper->lookupRecipient($recipient);
+      // Remove all non-digits from recipient identifier.
+      $recipientIdentifier = preg_replace('/[^\d]+/', '', $recipient);
+
+      $recipientLookupResult = $this->digitalPostHelper->lookupRecipient($recipientIdentifier);
       $actions = [
         (new Action())
           ->setActionCode(SF1601::ACTION_SELVBETJENING)


### PR DESCRIPTION
Combination of 

- [PR-189](https://github.com/OS2Forms/os2forms/pull/189)
  - Added support for MeMo 1.2 and added additional validation of MeMo actions.
- [PR-202](https://github.com/OS2Forms/os2forms/pull/202)
  - Removed non-digits from recipient id in Maestro digital post notifications.
- [PR-191](https://github.com/OS2Forms/os2forms/pull/191)
  - Re-throws exception to ensure failed status during Maestro notification job.