### PR TITLE
Make map element work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [PR-289](https://github.com/OS2Forms/os2forms/pull/289)
+  Added required "Zoom control position" to map element
+
 ## [5.0.0] 2025-11-18
 
 - [PR-192](https://github.com/OS2Forms/os2forms/pull/192)

--- a/modules/os2forms_webform_maps/os2forms_webform_maps.libraries.yml
+++ b/modules/os2forms_webform_maps/os2forms_webform_maps.libraries.yml
@@ -1,8 +1,5 @@
 webformmap:
   version: 1.x
-  css:
-    theme:
-      css/webform_map.css: {}
   js:
     js/webform_map.js: {}
   dependencies:

--- a/modules/os2forms_webform_maps/src/Element/WebformLeafletMapField.php
+++ b/modules/os2forms_webform_maps/src/Element/WebformLeafletMapField.php
@@ -5,6 +5,7 @@ namespace Drupal\os2forms_webform_maps\Element;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element\FormElement;
 use Drupal\webform\Element\WebformCompositeFormElementTrait;
+use Drupal\os2forms_webform_maps\Plugin\WebformElement\WebformLeafletMapField as WebformLeafletMapElement;
 
 /**
  * Provides a webform_map_field.
@@ -36,7 +37,7 @@ class WebformLeafletMapField extends FormElement {
       '#minZoom' => 1,
       '#maxZoom' => 18,
       '#zoomFiner' => 0,
-      '#position' => 'topleft',
+      '#position' => WebformLeafletMapElement::LEAFLET_POSITION_TOP_LEFT,
       '#marker' => 'defaultMarker',
       '#drawPolyline' => 0,
       '#drawRectangle' => 0,
@@ -90,7 +91,7 @@ class WebformLeafletMapField extends FormElement {
       'zoomFiner' => $element['#zoomFiner'],
       'minZoom' => $element['#minZoom'],
       'maxZoom' => $element['#maxZoom'],
-      'zoomControlPosition' => $element['#zoomControlPosition'] ?? 'topleft',
+      'zoomControlPosition' => $element['#zoomControlPosition'] ?? WebformLeafletMapElement::LEAFLET_POSITION_TOP_LEFT,
       'center' => [
         'lat' => (float) $element['#lat'],
         'lon' => (float) $element['#lon'],

--- a/modules/os2forms_webform_maps/src/Element/WebformLeafletMapField.php
+++ b/modules/os2forms_webform_maps/src/Element/WebformLeafletMapField.php
@@ -90,6 +90,7 @@ class WebformLeafletMapField extends FormElement {
       'zoomFiner' => $element['#zoomFiner'],
       'minZoom' => $element['#minZoom'],
       'maxZoom' => $element['#maxZoom'],
+      'zoomControlPosition' => $element['#zoomControlPosition'] ?? 'topleft',
       'center' => [
         'lat' => (float) $element['#lat'],
         'lon' => (float) $element['#lon'],

--- a/modules/os2forms_webform_maps/src/Plugin/WebformElement/WebformLeafletMapField.php
+++ b/modules/os2forms_webform_maps/src/Plugin/WebformElement/WebformLeafletMapField.php
@@ -22,10 +22,10 @@ class WebformLeafletMapField extends WebformElementBase {
 
   // Valid Leaflet control positions (cf.
   // https://github.com/Leaflet/Leaflet/blob/main/src/control/Control.js).
-  private const string LEAFLET_POSITION_TOP_LEFT = 'topleft';
-  private const string LEAFLET_POSITION_TOP_RIGHT = 'topright';
-  private const string LEAFLET_POSITION_BOTTOM_LEFT = 'bottomleft';
-  private const string LEAFLET_POSITION_BOTTOM_RIGHT = 'bottomright';
+  const string LEAFLET_POSITION_TOP_LEFT = 'topleft';
+  const string LEAFLET_POSITION_TOP_RIGHT = 'topright';
+  const string LEAFLET_POSITION_BOTTOM_LEFT = 'bottomleft';
+  const string LEAFLET_POSITION_BOTTOM_RIGHT = 'bottomright';
 
   /**
    * {@inheritdoc}

--- a/modules/os2forms_webform_maps/src/Plugin/WebformElement/WebformLeafletMapField.php
+++ b/modules/os2forms_webform_maps/src/Plugin/WebformElement/WebformLeafletMapField.php
@@ -20,6 +20,13 @@ class WebformLeafletMapField extends WebformElementBase {
 
   use LeafletSettingsElementsTrait;
 
+  // Valid Leaflet control positions (cf.
+  // https://github.com/Leaflet/Leaflet/blob/main/src/control/Control.js).
+  private const string LEAFLET_POSITION_TOP_LEFT = 'topleft';
+  private const string LEAFLET_POSITION_TOP_RIGHT = 'topright';
+  private const string LEAFLET_POSITION_BOTTOM_LEFT = 'bottomleft';
+  private const string LEAFLET_POSITION_BOTTOM_RIGHT = 'bottomright';
+
   /**
    * {@inheritdoc}
    */
@@ -33,10 +40,11 @@ class WebformLeafletMapField extends WebformElementBase {
       'minZoom' => 1,
       'maxZoom' => 18,
       'zoomFiner' => 0,
+      'zoomControlPosition' => self::LEAFLET_POSITION_TOP_LEFT,
       'scrollWheelZoom' => 0,
       'doubleClickZoom' => 1,
 
-      'position' => 'topleft',
+      'position' => self::LEAFLET_POSITION_TOP_LEFT,
       'marker' => 'defaultMarker',
       'drawPolyline' => 0,
       'drawRectangle' => 0,
@@ -71,6 +79,13 @@ class WebformLeafletMapField extends WebformElementBase {
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
     $map_keys = array_keys(leaflet_map_get_info());
+
+    $positionOptions = [
+      self::LEAFLET_POSITION_TOP_LEFT => $this->t('topleft'),
+      self::LEAFLET_POSITION_TOP_RIGHT => $this->t('topright'),
+      self::LEAFLET_POSITION_BOTTOM_LEFT => $this->t('bottomleft'),
+      self::LEAFLET_POSITION_BOTTOM_RIGHT => $this->t('bottomright'),
+    ];
 
     $form['mapstyles'] = [
       '#type' => 'fieldset',
@@ -139,6 +154,11 @@ class WebformLeafletMapField extends WebformElementBase {
         '#step' => 1,
         '#description' => $this->t('Value that might/will be added to default Fit Elements Bounds Zoom. (-5 / +5)'),
       ],
+      'zoomControlPosition' => [
+        '#type' => 'select',
+        '#title' => $this->t('Zoom control position'),
+        '#options' => $positionOptions,
+      ],
       'scrollWheelZoom' => [
         '#type' => 'checkbox',
         '#title' => $this->t('Enable Scroll Wheel Zoom on click'),
@@ -159,12 +179,7 @@ class WebformLeafletMapField extends WebformElementBase {
       'position' => [
         '#type' => 'select',
         '#title' => $this->t('Toolbar position.'),
-        '#options' => [
-          'topleft' => $this->t('topleft'),
-          'topright' => $this->t('topright'),
-          'bottomleft' => $this->t('bottomleft'),
-          'bottomright' => $this->t('bottomright'),
-        ],
+        '#options' => $positionOptions,
       ],
       'marker' => [
         '#type' => 'radios',


### PR DESCRIPTION
https://os2forms-leantime.itkdev.dk/_#/tickets/showTicket/180

Makes the map element work by adding “Zoom control position” to map element – Leaflet seems to require this setting. Also removes reference to nonexistent CSS file.

# Before

<img width="2752" height="1160" alt="Screen Shot 2026-02-03 at 10 55 46" src="https://github.com/user-attachments/assets/21cb39e5-80f4-48f9-8ffd-174ea591a917" />

The Browser console reports

``` console
Uncaught TypeError: can't access property "indexOf", i is undefined
    addTo Control.js:76
    addControl Control.js:137
    setPosition Control.js:52
    initialise leaflet.drupal.js:278
    Leaflet leaflet.drupal.js:225
    loadMap leaflet.drupal.js:23
    attach leaflet.drupal.js:193
    attach leaflet.drupal.js:15
    each jQuery
    attach leaflet.drupal.js:10
    attachBehaviors drupal.js:166
    attachBehaviors drupal.js:162
    insert ajax.js:1404
    jQuery 2
    insert ajax.js:1396
    commandExecutionQueue ajax.js:1046
    promise callback*Drupal.Ajax.prototype.commandExecutionQueue/< ajax.js:1039
    commandExecutionQueue ajax.js:1036
    success ajax.js:1095
    processReplacement big_pipe.js:84
    checkMutationAndProcess big_pipe.js:110
    processMutations big_pipe.js:134
    processMutations big_pipe.js:133
    MutationCallback* big_pipe.js:150
    <anonymous> big_pipe.js:184
Control.js:76:33
```

# After

<img width="2752" height="400" alt="Screen Shot 2026-02-03 at 10 58 24" src="https://github.com/user-attachments/assets/6b8af3c6-dbc4-4242-b618-24b7367c9452" />

> [!IMPORTANT]
> [The failing checks](https://github.com/OS2Forms/os2forms/pull/289/checks) are not related to changes in this pull request. Somebody has to clean up the checks to make them work again. https://github.com/OS2Forms/os2forms/issues/290 has been created to hopefully address this.



