### PR TITLE
Made digital signature text placement on attachment configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [PR-306](https://github.com/OS2Forms/os2forms/pull/306)
+  Made digital signature text placement configurable.
+
 ## [5.0.0] 2025-11-18
 
 - [PR-192](https://github.com/OS2Forms/os2forms/pull/192)

--- a/modules/os2forms_attachment/src/Element/AttachmentElement.php
+++ b/modules/os2forms_attachment/src/Element/AttachmentElement.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\os2forms_attachment\Element;
 
+use Drupal\os2forms_attachment\Os2formsAttachmentPrintBuilder;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\WebformSubmissionInterface;
 use Drupal\webform_attachment\Element\WebformAttachmentBase;
@@ -21,6 +22,7 @@ class AttachmentElement extends WebformAttachmentBase {
       '#view_mode' => 'html',
       '#export_type' => 'pdf',
       '#digital_signature' => FALSE,
+      '#digital_signature_position' => Os2formsAttachmentPrintBuilder::SIGNATURE_POSITION_AFTER_CONTENT,
       '#template' => '',
     ];
   }
@@ -77,7 +79,8 @@ class AttachmentElement extends WebformAttachmentBase {
 
         // Adding digital signature.
         if (isset($element['#digital_signature']) && $element['#digital_signature']) {
-          $file_path = $print_builder->savePrintableDigitalSignature([$webform_submission], $print_engine, $scheme, $file_name);
+          $signaturePosition = $element['#digital_signature_position'] ?? Os2formsAttachmentPrintBuilder::SIGNATURE_POSITION_AFTER_CONTENT;
+          $file_path = $print_builder->savePrintableDigitalSignature([$webform_submission], $print_engine, $scheme, $file_name, TRUE, $signaturePosition);
         }
         else {
           $file_path = $print_builder->savePrintable([$webform_submission], $print_engine, $scheme, $file_name);

--- a/modules/os2forms_attachment/src/Os2formsAttachmentPrintBuilder.php
+++ b/modules/os2forms_attachment/src/Os2formsAttachmentPrintBuilder.php
@@ -18,6 +18,11 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class Os2formsAttachmentPrintBuilder extends PrintBuilder {
 
+  public const SIGNATURE_POSITION_FOOTER = 'footer';
+  public const SIGNATURE_POSITION_HEADER = 'header';
+  public const SIGNATURE_POSITION_AFTER_CONTENT = 'after_content';
+  public const SIGNATURE_POSITION_BEFORE_CONTENT = 'before_content';
+
   /**
    * {@inheritdoc}
    */
@@ -52,8 +57,8 @@ class Os2formsAttachmentPrintBuilder extends PrintBuilder {
    * @return string
    *   FALSE or the URI to the file. E.g. public://my-file.pdf.
    */
-  public function savePrintableDigitalSignature(array $entities, PrintEngineInterface $print_engine, $scheme = 'public', $filename = FALSE, $use_default_css = TRUE) {
-    $renderer = $this->prepareRenderer($entities, $print_engine, $use_default_css, TRUE);
+  public function savePrintableDigitalSignature(array $entities, PrintEngineInterface $print_engine, $scheme = 'public', $filename = FALSE, $use_default_css = TRUE, string $signaturePosition = self::SIGNATURE_POSITION_AFTER_CONTENT) {
+    $renderer = $this->prepareRenderer($entities, $print_engine, $use_default_css, $signaturePosition);
 
     // Allow other modules to alter the generated Print object.
     $this->dispatcher->dispatch(new PreSendPrintEvent($print_engine, $entities), PrintEvents::PRE_SEND);
@@ -82,15 +87,16 @@ class Os2formsAttachmentPrintBuilder extends PrintBuilder {
    *   The print engine.
    * @param bool $use_default_css
    *   TRUE if we want the default CSS included.
-   * @param bool $digitalSignature
-   *   If the digital signature message needs to be added.
+   * @param string $signaturePosition
+   *   The position for the digital signature validation text. Empty string
+   *   means no signature. Use the SIGNATURE_POSITION_* class constants.
    *
    * @return \Drupal\entity_print\Renderer\RendererInterface
    *   A print renderer.
    *
    * @see PrintBuilder::prepareRenderer
    */
-  protected function prepareRenderer(array $entities, PrintEngineInterface $print_engine, $use_default_css, $digitalSignature = FALSE) {
+  protected function prepareRenderer(array $entities, PrintEngineInterface $print_engine, $use_default_css, string $signaturePosition = '') {
     if (empty($entities)) {
       throw new \InvalidArgumentException('You must pass at least 1 entity');
     }
@@ -106,12 +112,30 @@ class Os2formsAttachmentPrintBuilder extends PrintBuilder {
       '#attached' => [],
     ];
 
-    // Adding hardcoded negative margin to avoid margins in <fieldset> <legend>
-    // structure. That margin is automatically added in PDF and PDF only.
     $generatedHtml = (string) $renderer->generateHtml($entities, $render, $use_default_css, TRUE);
-    $generatedHtml .= "<style>fieldset legend {margin-left: -12px;}</style>";
-    if ($digitalSignature) {
-      $generatedHtml .= $this->t('You can validate the signature on this PDF file via validering.nemlog-in.dk.');
+
+    // Place signature according to the passed parameter.
+    if ($signaturePosition) {
+      $signatureHtml = '<div class="validate-signature-element"><p>' . $this->t('You can validate the signature on this PDF file via validering.nemlog-in.dk.') . '</p></div>';
+
+      switch ($signaturePosition) {
+        case self::SIGNATURE_POSITION_HEADER:
+          $generatedHtml = str_replace('</header>', $signatureHtml . '</header>', $generatedHtml);
+          break;
+
+        case self::SIGNATURE_POSITION_BEFORE_CONTENT:
+          $generatedHtml = str_replace('<div class="page">', '<div class="page">' . $signatureHtml, $generatedHtml);
+          break;
+
+        case self::SIGNATURE_POSITION_FOOTER:
+          $generatedHtml = str_replace('</footer>', $signatureHtml . '</footer>', $generatedHtml);
+          break;
+
+        case self::SIGNATURE_POSITION_AFTER_CONTENT:
+        default:
+          $generatedHtml = str_replace('</body>', $signatureHtml . '</body>', $generatedHtml);
+          break;
+      }
     }
 
     $print_engine->addPage($generatedHtml);

--- a/modules/os2forms_attachment/src/Os2formsAttachmentPrintBuilder.php
+++ b/modules/os2forms_attachment/src/Os2formsAttachmentPrintBuilder.php
@@ -49,8 +49,8 @@ class Os2formsAttachmentPrintBuilder extends PrintBuilder {
   /**
    * Modified version of the original savePrintable() function.
    *
-   * The only difference is modified call to prepareRenderer with digitalPost
-   * flag TRUE.
+   * The only difference is modified call to prepareRenderer with a
+   * signature position parameter.
    *
    * @see PrintBuilder::savePrintable()
    *

--- a/modules/os2forms_attachment/src/Plugin/WebformElement/AttachmentElement.php
+++ b/modules/os2forms_attachment/src/Plugin/WebformElement/AttachmentElement.php
@@ -5,6 +5,7 @@ namespace Drupal\os2forms_attachment\Plugin\WebformElement;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\webform\Twig\WebformTwigExtension;
 use Drupal\webform\Utility\WebformElementHelper;
+use Drupal\os2forms_attachment\Os2formsAttachmentPrintBuilder;
 use Drupal\webform_attachment\Plugin\WebformElement\WebformAttachmentBase;
 
 /**
@@ -28,6 +29,7 @@ class AttachmentElement extends WebformAttachmentBase {
       'template' => '',
       'export_type' => '',
       'digital_signature' => '',
+      'digital_signature_position' => 'after_content',
       'exclude_empty' => '',
       'exclude_empty_checkbox' => '',
       'excluded_elements' => '',
@@ -92,6 +94,23 @@ class AttachmentElement extends WebformAttachmentBase {
     $form['attachment']['digital_signature'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Digital signature'),
+    ];
+    $form['attachment']['digital_signature_position'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Digital signature position'),
+      '#description' => $this->t('Select where the digital signature validation text should be placed in the PDF document.'),
+      '#options' => [
+        Os2formsAttachmentPrintBuilder::SIGNATURE_POSITION_FOOTER => $this->t('Footer (repeats on every page)'),
+        Os2formsAttachmentPrintBuilder::SIGNATURE_POSITION_HEADER => $this->t('Header (repeats on every page)'),
+        Os2formsAttachmentPrintBuilder::SIGNATURE_POSITION_AFTER_CONTENT => $this->t('After content (end of document)'),
+        Os2formsAttachmentPrintBuilder::SIGNATURE_POSITION_BEFORE_CONTENT => $this->t('Before content (start of document)'),
+      ],
+      '#default_value' => Os2formsAttachmentPrintBuilder::SIGNATURE_POSITION_AFTER_CONTENT,
+      '#states' => [
+        'visible' => [
+          ':input[name="properties[digital_signature]"]' => ['checked' => TRUE],
+        ],
+      ],
     ];
 
     // Set #access so that help is always visible.

--- a/modules/os2forms_attachment/src/Plugin/WebformElement/AttachmentElement.php
+++ b/modules/os2forms_attachment/src/Plugin/WebformElement/AttachmentElement.php
@@ -29,7 +29,7 @@ class AttachmentElement extends WebformAttachmentBase {
       'template' => '',
       'export_type' => '',
       'digital_signature' => '',
-      'digital_signature_position' => 'after_content',
+      'digital_signature_position' => Os2formsAttachmentPrintBuilder::SIGNATURE_POSITION_AFTER_CONTENT,
       'exclude_empty' => '',
       'exclude_empty_checkbox' => '',
       'excluded_elements' => '',


### PR DESCRIPTION
During setup of digital signature we noticed the placement of the 'signature text' being a little wonky.

* Moves digital signature html into the main html generated
* Makes digital signature text placement configurable (default after content)
* Makes digital signature text targetable via css by giving it a class
