### PR TITLE
Added proper entity access en preview routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [PR-307](https://github.com/OS2Forms/os2forms/pull/307)
+  Added proper entity access checks on Maestro notification preview routes
+
 ## [5.0.0] 2025-11-18
 
 - [PR-192](https://github.com/OS2Forms/os2forms/pull/192)

--- a/modules/os2forms_forloeb/os2forms_forloeb.routing.yml
+++ b/modules/os2forms_forloeb/os2forms_forloeb.routing.yml
@@ -17,7 +17,7 @@ os2forms_forloeb.meastro_notification.preview:
       webform:
         type: 'entity:webform'
   requirements:
-    _permission: 'view any webform submission'
+    _entity_access: 'webform.view'
 
 os2forms_forloeb.meastro_notification.preview_render:
   path: '/admin/structure/webform/manage/{webform}/os2forms_forloeb/notification/{handler}/preview/{notification_type}/{content_type}/render/{submission}'
@@ -31,7 +31,7 @@ os2forms_forloeb.meastro_notification.preview_render:
       submission:
         type: 'entity:webform_submission'
   requirements:
-    _permission: 'view any webform submission'
+    _entity_access: 'submission.view'
 
 os2forms_forloeb.meastro_notification.preview_message:
   path: '/os2forms_forloeb/notification/message'


### PR DESCRIPTION
Adds proper entity access checks on preview routes.

The previous checks allowed any user with `view any webform submission` permission to preview submission data (if guessing a ~webform ID and a matching~ submission ID – which is pretty easy to do …).

If all users have access to all webforms and submissions, this is not an issue. However, if some sort of access checks are used to deny some users access to some webforms and submissions, e.g. by enabling the [OS2Forms permission by term module](/OS2Forms/os2forms/tree/develop/modules/os2forms_permissions_by_term) module[^1], all users will be able to preview any Maestro notification an any submission, i.e. only submissions on forms with a Maestro notification handler can be previewed (and only the data included in the notification).

[^1]: The [OS2Forms permission by term module](/OS2Forms/os2forms/tree/develop/modules/os2forms_permissions_by_term) module is missing an access check on wbforms submissions. The check has been added in https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/tree/develop/web/modules/custom/os2forms_permissions_by_term.

> [!NOTE]
> The failing checks will be resolved when/if https://github.com/OS2Forms/os2forms/issues/290 is completed.
