### PR TITLE
Fixed code analysis script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [PR-317](https://github.com/OS2Forms/os2forms/pull/317)
+  Updated code analysis script.
 - [PR-306](https://github.com/OS2Forms/os2forms/pull/306)
   Made digital signature text placement configurable.
 - [#251](https://github.com/OS2Forms/os2forms/issues/251)

--- a/scripts/code-analysis
+++ b/scripts/code-analysis
@@ -40,7 +40,7 @@ drupal_composer config --no-plugins allow-plugins true
 
 # Making Drupal 10 compatible
 drupal_composer require psr/http-message:^1.0
-drupal_composer require mglaman/composer-drupal-lenient
+drupal_composer require mglaman/composer-drupal-lenient:^1.0
 drupal_composer config --merge --json extra.drupal-lenient.allowed-list '["drupal/coc_forms_auto_export", "drupal/webform_node_element"]'
 
 drupal_composer require wikimedia/composer-merge-plugin


### PR DESCRIPTION
Fixes code analysis script after new  [drupal lenient](https://github.com/mglaman/composer-drupal-lenient/releases/tag/2.0.0) `2.0.0`.

The `2.0.0` version requires drupal core 11 (or [12?](https://github.com/mglaman/composer-drupal-lenient/blob/main/composer.json#L28)). To ensure a compatibility we requiring with `^1.0` in the code-analysis script.

