### PR TITLE
Allow configurating on which submission states handlers should run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
-- Added the ability to configure on which submission states handlers should run.
+- [PR-333](https://github.com/OS2Forms/os2forms/pull/333)
+  Added the ability to configure on which submission states handlers should run.
   The default option is to run on the completed state. Changes was made to the
   following handlers:
   - Digital post

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- Added the ability to configure on which submission states handlers should run.
+  The default option is to run on the completed state. Changes was made to the
+  following handlers:
+  - Digital post
+  - Fasit
+  - FBS
+  - Digital signature
+
 ## [5.1.0] 2026-06-03
 
 - [PR-326](https://github.com/OS2Forms/os2forms/pull/326)

--- a/modules/os2forms_digital_post/os2forms_digital_post.install
+++ b/modules/os2forms_digital_post/os2forms_digital_post.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\os2forms_digital_post\Helper\BeskedfordelerHelper;
+use Drupal\webform\WebformSubmissionInterface;
 
 /**
  * Implements hook_schema().
@@ -25,4 +26,35 @@ function os2forms_digital_post_update_9001(): void {
   \Drupal::service('module_installer')->install([
     'os2web_key',
   ], TRUE);
+}
+
+/**
+ * Set states config to completed on existing digital post handlers.
+ */
+function os2forms_digital_post_update_10001(): void {
+  // To avoid having to load full webforms we load and update webform configs.
+  $configFactory = \Drupal::configFactory();
+
+  foreach ($configFactory->listAll('webform.webform.') as $name) {
+    $config = $configFactory->getEditable($name);
+    $handlers = $config->get('handlers');
+    if (!is_array($handlers)) {
+      continue;
+    }
+
+    $changed = FALSE;
+
+    foreach ($handlers as $handlerKey => $handler) {
+      // $handler['id'] is the handler plugin id.
+      if (($handler['id'] ?? NULL) !== 'digital_post_sf1601') {
+        continue;
+      }
+      $handlers[$handlerKey]['settings']['additional']['states'] = [WebformSubmissionInterface::STATE_COMPLETED];
+      $changed = TRUE;
+    }
+
+    if ($changed) {
+      $config->set('handlers', $handlers)->save();
+    }
+  }
 }

--- a/modules/os2forms_digital_post/src/Plugin/WebformHandler/WebformHandlerSF1601.php
+++ b/modules/os2forms_digital_post/src/Plugin/WebformHandler/WebformHandlerSF1601.php
@@ -32,6 +32,8 @@ final class WebformHandlerSF1601 extends WebformHandlerBase {
   public const RECIPIENT_ELEMENT = 'recipient_element';
   public const ATTACHMENT_ELEMENT = 'attachment_element';
   public const SENDER_ADDRESS = 'sender_address';
+  private const string ADDITIONAL = 'additional';
+  private const string STATES = 'states';
 
   /**
    * Maximum length of sender label.
@@ -76,6 +78,9 @@ final class WebformHandlerSF1601 extends WebformHandlerBase {
   public function defaultConfiguration() {
     return [
       'debug' => FALSE,
+      self::ADDITIONAL => [
+        self::STATES => [WebformSubmissionInterface::STATE_COMPLETED],
+      ],
     ];
   }
 
@@ -201,6 +206,31 @@ final class WebformHandlerSF1601 extends WebformHandlerBase {
       '#description' => $this->t('If checked, every handler method invoked will be displayed onscreen to all users.'),
       '#return_value' => TRUE,
       '#default_value' => $this->configuration['debug'] ?? NULL,
+    ];
+
+    // Additional.
+    // Lifted from EmailWebformHandler::buildConfigurationForm().
+    $resultsDisabled = (bool) $this->getWebform()->getSetting('results_disabled');
+    $form[self::ADDITIONAL] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Additional settings'),
+    ];
+    // Settings: States.
+    $states = (array) ($this->configuration[self::ADDITIONAL][self::STATES] ?? NULL);
+    $form[self::ADDITIONAL][self::STATES] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Run handler when …'),
+      '#options' => [
+        WebformSubmissionInterface::STATE_DRAFT_CREATED => $this->t('<b>draft is created</b>.'),
+        WebformSubmissionInterface::STATE_DRAFT_UPDATED => $this->t('<b>draft is updated</b>.'),
+        WebformSubmissionInterface::STATE_CONVERTED => $this->t('anonymous <b>submission is converted</b> to authenticated.'),
+        WebformSubmissionInterface::STATE_COMPLETED => $this->t('<b>submission is completed</b>.'),
+        WebformSubmissionInterface::STATE_UPDATED => $this->t('<b>submission is updated</b>.'),
+        WebformSubmissionInterface::STATE_DELETED => $this->t('<b>submission is deleted</b>.'),
+        WebformSubmissionInterface::STATE_LOCKED => $this->t('<b>submission is locked</b>.'),
+      ],
+      '#access' => !$resultsDisabled,
+      '#default_value' => $resultsDisabled ? [WebformSubmissionInterface::STATE_COMPLETED] : $states,
     ];
 
     return $this->setSettingsParents($form);
@@ -333,6 +363,11 @@ final class WebformHandlerSF1601 extends WebformHandlerBase {
     $this->configuration[self::MEMO_ACTIONS] = $actions;
 
     $this->configuration['debug'] = (bool) $formState->getValue('debug');
+
+    $additional = $formState->getValue(self::ADDITIONAL);
+    // Clean up states.
+    $additional[self::STATES] = array_values(array_filter($additional[self::STATES]));
+    $this->configuration[self::ADDITIONAL] = $additional;
   }
 
   /**
@@ -341,6 +376,12 @@ final class WebformHandlerSF1601 extends WebformHandlerBase {
    * @phpstan-return void
    */
   public function postSave(WebformSubmissionInterface $webformSubmission, $update = TRUE) {
+    $submissionState = $webformSubmission->getWebform()->getSetting('results_disabled') ? WebformSubmissionInterface::STATE_COMPLETED : $webformSubmission->getState();
+    $enabledStates = (array) ($this->configuration[self::ADDITIONAL][self::STATES] ?? NULL);
+    if (!in_array($submissionState, $enabledStates)) {
+      return;
+    }
+
     $this->helper->createJob($webformSubmission, $this->configuration);
   }
 

--- a/modules/os2forms_digital_signature/os2forms_digital_signature.install
+++ b/modules/os2forms_digital_signature/os2forms_digital_signature.install
@@ -2,24 +2,15 @@
 
 /**
  * @file
- * Install hooks for os2forms_fasit.
+ * Install hooks for os2forms_digital_signature.
  */
 
 use Drupal\webform\WebformSubmissionInterface;
 
 /**
- * Install Key module.
+ * Set states config to completed on existing digital signature handlers.
  */
-function os2forms_fasit_update_9001(): void {
-  \Drupal::service('module_installer')->install([
-    'key',
-  ], TRUE);
-}
-
-/**
- * Set states config to completed on existing fasit handlers.
- */
-function os2forms_fasit_update_10001(): void {
+function os2forms_digital_signature_update_10001(): void {
   // To avoid having to load full webforms we load and update webform configs.
   $configFactory = \Drupal::configFactory();
 
@@ -34,7 +25,7 @@ function os2forms_fasit_update_10001(): void {
 
     foreach ($handlers as $handlerKey => $handler) {
       // $handler['id'] is the handler plugin id.
-      if (($handler['id'] ?? NULL) !== 'os2forms_fasit') {
+      if (($handler['id'] ?? NULL) !== 'os2forms_digital_signature') {
         continue;
       }
       $handlers[$handlerKey]['settings']['additional']['states'] = [WebformSubmissionInterface::STATE_COMPLETED];

--- a/modules/os2forms_digital_signature/src/Plugin/WebformHandler/DigitalSignatureWebformHandler.php
+++ b/modules/os2forms_digital_signature/src/Plugin/WebformHandler/DigitalSignatureWebformHandler.php
@@ -7,6 +7,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\Url;
 use Drupal\file\FileRepositoryInterface;
@@ -88,6 +89,9 @@ class DigitalSignatureWebformHandler extends WebformHandlerBase {
    */
   private readonly Settings $settings;
 
+  private const string ADDITIONAL = 'additional';
+  private const string STATES = 'states';
+
   /**
    * {@inheritdoc}
    */
@@ -107,13 +111,77 @@ class DigitalSignatureWebformHandler extends WebformHandlerBase {
 
   /**
    * {@inheritdoc}
+   *
+   * @phpstan-return array<string, mixed>
+   */
+  public function defaultConfiguration() {
+    return [
+      self::ADDITIONAL => [
+        self::STATES => [WebformSubmissionInterface::STATE_COMPLETED],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @phpstan-param array<string, mixed> $form
+   * @phpstan-return array<string, mixed>
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    // Additional.
+    // Lifted from EmailWebformHandler::buildConfigurationForm().
+    $resultsDisabled = (bool) $this->getWebform()->getSetting('results_disabled');
+    $form[self::ADDITIONAL] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Additional settings'),
+    ];
+    // Settings: States.
+    $states = (array) ($this->configuration[self::ADDITIONAL][self::STATES] ?? NULL);
+    $form[self::ADDITIONAL][self::STATES] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Run handler when …'),
+      '#options' => [
+        WebformSubmissionInterface::STATE_DRAFT_CREATED => $this->t('<b>draft is created</b>.'),
+        WebformSubmissionInterface::STATE_DRAFT_UPDATED => $this->t('<b>draft is updated</b>.'),
+        WebformSubmissionInterface::STATE_CONVERTED => $this->t('anonymous <b>submission is converted</b> to authenticated.'),
+        WebformSubmissionInterface::STATE_COMPLETED => $this->t('<b>submission is completed</b>.'),
+        WebformSubmissionInterface::STATE_UPDATED => $this->t('<b>submission is updated</b>.'),
+        WebformSubmissionInterface::STATE_DELETED => $this->t('<b>submission is deleted</b>.'),
+        // The digital signature logic locks after the first signing. Resigning
+        // does not make sense, so 'locked' is not an option here.
+      ],
+      '#access' => !$resultsDisabled,
+      '#default_value' => $resultsDisabled ? [WebformSubmissionInterface::STATE_COMPLETED] : $states,
+    ];
+
+    return $this->setSettingsParents($form);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @phpstan-param array<string, mixed> $form
+   * @phpstan-return void
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $additional = $form_state->getValue(self::ADDITIONAL);
+    // Clean up states.
+    $additional[self::STATES] = array_values(array_filter($additional[self::STATES]));
+    $this->configuration[self::ADDITIONAL] = $additional;
+  }
+
+  /**
+   * {@inheritdoc}
    */
   public function preSave(WebformSubmissionInterface $webform_submission) {
-    $webform = $webform_submission->getWebform();
-
-    if ($webform_submission->isLocked()) {
+    $submissionState = $webform_submission->getWebform()->getSetting('results_disabled') ? WebformSubmissionInterface::STATE_COMPLETED : $webform_submission->getState();
+    $enabledStates = (array) ($this->configuration[self::ADDITIONAL][self::STATES] ?? NULL);
+    if (!in_array($submissionState, $enabledStates)) {
       return;
     }
+
+    $webform = $webform_submission->getWebform();
 
     $attachment = $this->getSubmissionAttachment($webform_submission);
     if (!$attachment) {

--- a/modules/os2forms_fasit/src/Plugin/WebformHandler/FasitWebformHandler.php
+++ b/modules/os2forms_fasit/src/Plugin/WebformHandler/FasitWebformHandler.php
@@ -35,6 +35,8 @@ class FasitWebformHandler extends WebformHandlerBase {
   public const FASIT_HANDLER_DOCUMENT_DESCRIPTION = 'document_description';
   public const FASIT_HANDLER_CPR_ELEMENT = 'cpr_element';
   public const FASIT_HANDLER_ATTACHMENT_ELEMENT = 'attachment_element';
+  private const string ADDITIONAL = 'additional';
+  private const string STATES = 'states';
 
   /**
    * The submission logger.
@@ -77,6 +79,19 @@ class FasitWebformHandler extends WebformHandlerBase {
       $container->get('webform_submission.conditions_validator'),
       $container->get('webform.token_manager')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @phpstan-return array<string, mixed>
+   */
+  public function defaultConfiguration() {
+    return [
+      self::ADDITIONAL => [
+        self::STATES => [WebformSubmissionInterface::STATE_COMPLETED],
+      ],
+    ];
   }
 
   /**
@@ -129,6 +144,31 @@ class FasitWebformHandler extends WebformHandlerBase {
       '#size' => 5,
     ];
 
+    // Additional.
+    // Lifted from EmailWebformHandler::buildConfigurationForm().
+    $resultsDisabled = (bool) $this->getWebform()->getSetting('results_disabled');
+    $form[self::ADDITIONAL] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Additional settings'),
+    ];
+    // Settings: States.
+    $states = (array) ($this->configuration[self::ADDITIONAL][self::STATES] ?? NULL);
+    $form[self::ADDITIONAL][self::STATES] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Run handler when …'),
+      '#options' => [
+        WebformSubmissionInterface::STATE_DRAFT_CREATED => $this->t('<b>draft is created</b>.'),
+        WebformSubmissionInterface::STATE_DRAFT_UPDATED => $this->t('<b>draft is updated</b>.'),
+        WebformSubmissionInterface::STATE_CONVERTED => $this->t('anonymous <b>submission is converted</b> to authenticated.'),
+        WebformSubmissionInterface::STATE_COMPLETED => $this->t('<b>submission is completed</b>.'),
+        WebformSubmissionInterface::STATE_UPDATED => $this->t('<b>submission is updated</b>.'),
+        WebformSubmissionInterface::STATE_DELETED => $this->t('<b>submission is deleted</b>.'),
+        WebformSubmissionInterface::STATE_LOCKED => $this->t('<b>submission is locked</b>.'),
+      ],
+      '#access' => !$resultsDisabled,
+      '#default_value' => $resultsDisabled ? [WebformSubmissionInterface::STATE_COMPLETED] : $states,
+    ];
+
     return $this->setSettingsParents($form);
   }
 
@@ -143,12 +183,23 @@ class FasitWebformHandler extends WebformHandlerBase {
     $this->configuration[self::FASIT_HANDLER_GENERAL][self::FASIT_HANDLER_DOCUMENT_DESCRIPTION] = $form_state->getValue(self::FASIT_HANDLER_GENERAL)[self::FASIT_HANDLER_DOCUMENT_DESCRIPTION];
     $this->configuration[self::FASIT_HANDLER_GENERAL][self::FASIT_HANDLER_CPR_ELEMENT] = $form_state->getValue(self::FASIT_HANDLER_GENERAL)[self::FASIT_HANDLER_CPR_ELEMENT];
     $this->configuration[self::FASIT_HANDLER_GENERAL][self::FASIT_HANDLER_ATTACHMENT_ELEMENT] = $form_state->getValue(self::FASIT_HANDLER_GENERAL)[self::FASIT_HANDLER_ATTACHMENT_ELEMENT];
+
+    $additional = $form_state->getValue(self::ADDITIONAL);
+    // Clean up states.
+    $additional[self::STATES] = array_values(array_filter($additional[self::STATES]));
+    $this->configuration[self::ADDITIONAL] = $additional;
   }
 
   /**
    * {@inheritdoc}
    */
   public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE): void {
+    $submissionState = $webform_submission->getWebform()->getSetting('results_disabled') ? WebformSubmissionInterface::STATE_COMPLETED : $webform_submission->getState();
+    $enabledStates = (array) ($this->configuration[self::ADDITIONAL][self::STATES] ?? NULL);
+    if (!in_array($submissionState, $enabledStates)) {
+      return;
+    }
+
     $queueStorage = $this->entityTypeManager->getStorage('advancedqueue_queue');
     /** @var \Drupal\advancedqueue\Entity\Queue $queue */
     $queue = $queueStorage->load('fasit_queue');

--- a/modules/os2forms_fbs_handler/os2forms_fbs_handler.install
+++ b/modules/os2forms_fbs_handler/os2forms_fbs_handler.install
@@ -2,24 +2,15 @@
 
 /**
  * @file
- * Install hooks for os2forms_fasit.
+ * Install hooks for os2forms_fbs_handler.
  */
 
 use Drupal\webform\WebformSubmissionInterface;
 
 /**
- * Install Key module.
+ * Set states config to completed on existing fbs handlers.
  */
-function os2forms_fasit_update_9001(): void {
-  \Drupal::service('module_installer')->install([
-    'key',
-  ], TRUE);
-}
-
-/**
- * Set states config to completed on existing fasit handlers.
- */
-function os2forms_fasit_update_10001(): void {
+function os2forms_fbs_handler_update_10001(): void {
   // To avoid having to load full webforms we load and update webform configs.
   $configFactory = \Drupal::configFactory();
 
@@ -34,7 +25,7 @@ function os2forms_fasit_update_10001(): void {
 
     foreach ($handlers as $handlerKey => $handler) {
       // $handler['id'] is the handler plugin id.
-      if (($handler['id'] ?? NULL) !== 'os2forms_fasit') {
+      if (($handler['id'] ?? NULL) !== 'os2forms_fbs') {
         continue;
       }
       $handlers[$handlerKey]['settings']['additional']['states'] = [WebformSubmissionInterface::STATE_COMPLETED];

--- a/modules/os2forms_fbs_handler/src/Plugin/WebformHandler/FbsWebformHandler.php
+++ b/modules/os2forms_fbs_handler/src/Plugin/WebformHandler/FbsWebformHandler.php
@@ -42,6 +42,8 @@ final class FbsWebformHandler extends WebformHandlerBase {
    * The queue id.
    */
   private const QUEUE_ID = 'os2forms_fbs_handler';
+  private const string ADDITIONAL = 'additional';
+  private const string STATES = 'states';
 
   /**
    * Constructs an FbsWebformHandler object.
@@ -87,6 +89,19 @@ final class FbsWebformHandler extends WebformHandlerBase {
       $container->get('webform_submission.conditions_validator'),
       $container->get('webform.token_manager')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @phpstan-return array<string, mixed>
+   */
+  public function defaultConfiguration() {
+    return [
+      self::ADDITIONAL => [
+        self::STATES => [WebformSubmissionInterface::STATE_COMPLETED],
+      ],
+    ];
   }
 
   /**
@@ -146,6 +161,31 @@ final class FbsWebformHandler extends WebformHandlerBase {
       '#default_value' => $this->configuration['password'] ?? '',
     ];
 
+    // Additional.
+    // Lifted from EmailWebformHandler::buildConfigurationForm().
+    $resultsDisabled = (bool) $this->getWebform()->getSetting('results_disabled');
+    $form[self::ADDITIONAL] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Additional settings'),
+    ];
+    // Settings: States.
+    $states = (array) ($this->configuration[self::ADDITIONAL][self::STATES] ?? NULL);
+    $form[self::ADDITIONAL][self::STATES] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Run handler when …'),
+      '#options' => [
+        WebformSubmissionInterface::STATE_DRAFT_CREATED => $this->t('<b>draft is created</b>.'),
+        WebformSubmissionInterface::STATE_DRAFT_UPDATED => $this->t('<b>draft is updated</b>.'),
+        WebformSubmissionInterface::STATE_CONVERTED => $this->t('anonymous <b>submission is converted</b> to authenticated.'),
+        WebformSubmissionInterface::STATE_COMPLETED => $this->t('<b>submission is completed</b>.'),
+        WebformSubmissionInterface::STATE_UPDATED => $this->t('<b>submission is updated</b>.'),
+        WebformSubmissionInterface::STATE_DELETED => $this->t('<b>submission is deleted</b>.'),
+        WebformSubmissionInterface::STATE_LOCKED => $this->t('<b>submission is locked</b>.'),
+      ],
+      '#access' => !$resultsDisabled,
+      '#default_value' => $resultsDisabled ? [WebformSubmissionInterface::STATE_COMPLETED] : $states,
+    ];
+
     return $this->setSettingsParents($form);
   }
 
@@ -164,12 +204,23 @@ final class FbsWebformHandler extends WebformHandlerBase {
       ->getValue(['wrapper', 'username']);
     $this->configuration['password'] = $form_state
       ->getValue(['wrapper', 'password']);
+
+    $additional = $form_state->getValue(self::ADDITIONAL);
+    // Clean up states.
+    $additional[self::STATES] = array_values(array_filter($additional[self::STATES]));
+    $this->configuration[self::ADDITIONAL] = $additional;
   }
 
   /**
    * {@inheritdoc}
    */
   public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE): void {
+    $submissionState = $webform_submission->getWebform()->getSetting('results_disabled') ? WebformSubmissionInterface::STATE_COMPLETED : $webform_submission->getState();
+    $enabledStates = (array) ($this->configuration[self::ADDITIONAL][self::STATES] ?? NULL);
+    if (!in_array($submissionState, $enabledStates)) {
+      return;
+    }
+
     $logger_context = [
       'handler_id' => 'os2forms_fbs',
       'channel' => 'webform_submission',


### PR DESCRIPTION
Closes https://github.com/OS2Forms/os2forms/issues/334

When using digital signature other handlers should be modified to run on "locked" submission state.

This PR adds configuration to handlers that allow stating on which states the handler should run, akin to the e-mail handler.

The default state on which handlers run are "completed". 