### PR TITLE
336: Avoided inheriting data on page transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [337](https://github.com/OS2Forms/os2forms/pull/337)
+  Avoid inheriting data on page transition in MaestroWebformInheritTask.
+
 ## [5.1.0] 2026-06-03
 
 - [PR-326](https://github.com/OS2Forms/os2forms/pull/326)

--- a/modules/os2forms_forloeb/src/Plugin/EngineTasks/MaestroWebformInheritTask.php
+++ b/modules/os2forms_forloeb/src/Plugin/EngineTasks/MaestroWebformInheritTask.php
@@ -144,6 +144,13 @@ class MaestroWebformInheritTask extends MaestroWebformTask {
    * Implements hook_webform_submission_form_alter().
    */
   public static function webformSubmissionFormAlter(array &$form, FormStateInterface $formState, string $formId) {
+    // Only inherit values on the initial form load. This skip condition is the
+    // complement of webform's own prepopulate guard.
+    // @see \Drupal\webform\WebformSubmissionForm::buildForm()
+    if ($formState->isRebuilding() && !$formState->get('is_ajax_restart')) {
+      return;
+    }
+
     // @todo Clean up and align with MaestroHelper::maestroZeroUserNotification().
     if ($queueID = self::getQueueIdFromRequest()) {
       $templateTask = MaestroEngine::getTemplateTaskByQueueID($queueID);


### PR DESCRIPTION
Closes https://github.com/OS2Forms/os2forms/issues/336.

When a WebformInherit-task (`os2forms_forloeb`) inherits a submission into a multi-page wizard, edits made on any page other than the final one are silently discarded on submit.

This PR adds guard to ensure data is not inherited on page transition.