### PR TITLE
338: Correctly inherit single files in MaestroInheritTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ before starting to add changes. Use example [placed in the end of the page](#exa
 
 ## [Unreleased]
 
+- [PR-339](https://github.com/OS2Forms/os2forms/pull/339)
+  Ensure MaestroInheritTask correctly inherits file-elements.
+
 ## [5.1.0] 2026-06-03
 
 - [PR-326](https://github.com/OS2Forms/os2forms/pull/326)

--- a/modules/os2forms_forloeb/src/Plugin/EngineTasks/MaestroWebformInheritTask.php
+++ b/modules/os2forms_forloeb/src/Plugin/EngineTasks/MaestroWebformInheritTask.php
@@ -8,6 +8,7 @@ use Drupal\maestro\Engine\MaestroEngine;
 use Drupal\maestro_webform\Plugin\EngineTasks\MaestroWebformTask;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
+use Drupal\webform\Plugin\WebformElement\WebformManagedFileBase;
 use Drupal\webform\Utility\WebformArrayHelper;
 
 /**
@@ -160,10 +161,18 @@ class MaestroWebformInheritTask extends MaestroWebformTask {
             // element information to properly set default element values nested
             // inside the form.
             if ($targetWebform = Webform::load($form['#webform_id'] ?? NULL)) {
+              $elementManager = \Drupal::service('plugin.manager.webform.element');
               foreach ($data as $key => $value) {
                 if ($targetElement = $targetWebform->getElement($key)) {
                   if ($element = &NestedArray::getValue($form['elements'], $targetElement['#webform_parents'])) {
-                    $element['#default_value'] = $value;
+                    // File elements need their default values as an array.
+                    // @see \Drupal\webform\Plugin\WebformElement\WebformManagedFileBase::setDefaultValue()
+                    if ($elementManager->getElementInstance($element) instanceof WebformManagedFileBase) {
+                      $element['#default_value'] = (array) $value;
+                    }
+                    else {
+                      $element['#default_value'] = $value;
+                    }
                   }
                 }
               }

--- a/modules/os2forms_forloeb/src/Plugin/EngineTasks/MaestroWebformInheritTask.php
+++ b/modules/os2forms_forloeb/src/Plugin/EngineTasks/MaestroWebformInheritTask.php
@@ -168,11 +168,9 @@ class MaestroWebformInheritTask extends MaestroWebformTask {
                     // A file element needs its default value as an array.
                     // @see \Drupal\webform\Plugin\WebformElement\WebformManagedFileBase::setDefaultValue()
                     if ($elementManager->getElementInstance($element) instanceof WebformManagedFileBase) {
-                      $element['#default_value'] = (array) $value;
+                      $value = (array) $value;
                     }
-                    else {
-                      $element['#default_value'] = $value;
-                    }
+                    $element['#default_value'] = $value;
                   }
                 }
               }

--- a/modules/os2forms_forloeb/src/Plugin/EngineTasks/MaestroWebformInheritTask.php
+++ b/modules/os2forms_forloeb/src/Plugin/EngineTasks/MaestroWebformInheritTask.php
@@ -165,7 +165,7 @@ class MaestroWebformInheritTask extends MaestroWebformTask {
               foreach ($data as $key => $value) {
                 if ($targetElement = $targetWebform->getElement($key)) {
                   if ($element = &NestedArray::getValue($form['elements'], $targetElement['#webform_parents'])) {
-                    // File elements need their default values as an array.
+                    // A file element needs its default value as an array.
                     // @see \Drupal\webform\Plugin\WebformElement\WebformManagedFileBase::setDefaultValue()
                     if ($elementManager->getElementInstance($element) instanceof WebformManagedFileBase) {
                       $element['#default_value'] = (array) $value;


### PR DESCRIPTION
Closes https://github.com/OS2Forms/os2forms/issues/338.

When the MaestroInheritTask attempts setting a default value containing a singular file it fails due to incorrect type.

PR ensures the values being set as default value, for any element implementing `WebformManagedFileBase`, is an array.

> [!NOTE]
> A general cleanup of the `MaestroInheritTask` should be done. We should generally avoid static `\Drupal::` calls, but that is out of scope for this fix.